### PR TITLE
Replace pkg_resources from setuptools by Python standard lib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,9 @@
 # import os
 # import sys
 
-import pkg_resources
+import importlib.metadata
 
-version = pkg_resources.get_distribution("prospector").version
+version = importlib.metadata.version("prospector")
 
 release = ".".join(version.split(".")[:2])
 

--- a/prospector/blender.py
+++ b/prospector/blender.py
@@ -4,9 +4,9 @@
 # the same line. For example, both pyflakes and pylint will generate an
 # "Unused Import" warning on the same line. This is obviously redundant, so we
 # remove duplicates.
+import pkgutil
 from collections import defaultdict
 
-import pkg_resources
 import yaml
 
 __all__ = (
@@ -98,7 +98,7 @@ def blend(messages, blend_combos=None):
 
 
 def get_default_blend_combinations():
-    combos = yaml.safe_load(pkg_resources.resource_string(__name__, "blender_combinations.yaml"))
+    combos = yaml.safe_load(pkgutil.get_data(__name__, "blender_combinations.yaml"))
     combos = combos.get("combinations", [])
 
     defaults = []

--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -1,5 +1,6 @@
 # flake8: noqa
-import pkg_resources
+import importlib.metadata
+
 import setoptconf as soc
 
 from prospector.config.datatype import OutputChoice
@@ -8,7 +9,7 @@ from prospector.tools import DEFAULT_TOOLS, TOOLS
 
 __all__ = ("build_manager",)
 
-_VERSION = pkg_resources.get_distribution("prospector").version
+_VERSION = importlib.metadata.version("prospector")
 
 
 def build_manager():


### PR DESCRIPTION
## Related Issue

Fix https://github.com/landscapeio/prospector/issues/656 and https://github.com/landscapeio/prospector/issues/646

## Motivation and Context

Support Python 3.12 fully and easily

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
