### PR TITLE
Be able to see the Unrecognized options

### DIFF
--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -2,10 +2,14 @@ from pathlib import Path
 
 from packaging import version as packaging_version
 from pylint import version as pylint_version
-from pylint.config.config_file_parser import _ConfigurationFileParser
-from pylint.config.config_initialization import _order_all_first
+from pylint.config.config_initialization import _config_initialization
 from pylint.lint import PyLinter
-from pylint.utils import _splitstrip, utils
+
+
+class UnrecognizedOptions(Exception):
+    """Raised when an unrecognized option is found in the Pylint configuration."""
+
+    pass
 
 
 class ProspectorLinter(PyLinter):
@@ -16,47 +20,8 @@ class ProspectorLinter(PyLinter):
 
     # Largely inspired by https://github.com/pylint-dev/pylint/blob/main/pylint/config/config_initialization.py#L26
     def config_from_file(self, config_file=None):
-        """Will return `True` if plugins have been loaded. For pylint>=1.5. Else `False`."""
-        config_file_parser = _ConfigurationFileParser(False, self)
-        config_data, config_args = config_file_parser.parse_config_file(file_path=config_file)
-        if config_data.get("MASTER", {}).get("load-plugins"):
-            plugins = _splitstrip(config_data["MASTER"]["load-plugins"])
-            self.load_plugin_modules(plugins)
-
-        config_args = _order_all_first(config_args, joined=False)
-
-        if "init-hook" in config_data:
-            exec(utils._unquote(config_data["init-hook"]))  # pylint: disable=exec-used
-
-        # Load plugins if specified in the config file
-        if "load-plugins" in config_data:
-            self.load_plugin_modules(utils._splitstrip(config_data["load-plugins"]))
-
-        self._parse_configuration_file(config_args)
-
-        # Set the current module to the command line
-        # to allow raising messages on it
-        self.set_current_module(config_file)
-
-        self._emit_stashed_messages()
-
-        # Set the current module to configuration as we don't know where
-        # the --load-plugins key is coming from
-        self.set_current_module("Command line or configuration file")
-
-        # We have loaded configuration from config file and command line. Now, we can
-        # load plugin specific configuration.
-        self.load_plugin_configuration()
-
-        # Now that plugins are loaded, get list of all fail_on messages, and
-        # enable them
-        self.enable_fail_on_messages()
-
-        self._parse_error_mode()
-
-        # Link the base Namespace object on the current directory
-        self._directory_namespaces[Path().resolve()] = (self.config, {})
-
+        """Initialize the configuration from a file."""
+        _config_initialization(self, [], config_file=config_file)
         return True
 
     def _expand_files(self, modules):


### PR DESCRIPTION
## Description

With the new version I get:
```
Traceback (most recent call last):
  File "/usr/local/bin/prospector", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/prospector/run.py", line 198, in main
    prospector.execute()
  File "/usr/local/lib/python3.10/dist-packages/prospector/run.py", line 73, in execute
    for tool in self.config.get_tools(found_files):
  File "/usr/local/lib/python3.10/dist-packages/prospector/config/__init__.py", line 68, in get_tools
    config_result = tool.configure(self, found_files)
  File "/usr/local/lib/python3.10/dist-packages/prospector/tools/pylint/__init__.py", line 114, in configure
    config_messages, configured_by = self._get_pylint_configuration(
  File "/usr/local/lib/python3.10/dist-packages/prospector/tools/pylint/__init__.py", line 200, in _get_pylint_configuration
    config_messages += self._pylintrc_configure(pylintrc, linter)
  File "/usr/local/lib/python3.10/dist-packages/prospector/tools/pylint/__init__.py", line 96, in _pylintrc_configure
    are_plugins_loaded = linter.config_from_file(pylintrc)
  File "/usr/local/lib/python3.10/dist-packages/prospector/tools/pylint/linter.py", line 35, in config_from_file
    self._parse_configuration_file(config_args)
  File "/usr/local/lib/python3.10/dist-packages/pylint/config/arguments_manager.py", line 222, in _parse_configuration_file
    raise _UnrecognizedOptionError(options=unrecognized_options)
pylint.config.exceptions._UnrecognizedOptionError
```
But no way to know witch option is not recognized because the Pylint exception didn't print it:
https://github.com/pylint-dev/pylint/blob/main/pylint/config/exceptions.py#L14

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
