### PR TITLE
Be able to pass options to Bandit

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -60,3 +60,8 @@ pydocstyle:
     - D205
     - D400
     - D401
+
+bandit:
+  run: true
+  disable:
+  - B101 # Use of assert detected.

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -398,6 +398,8 @@ The available options are:
 +----------------+------------------------+----------------------------------------------+
 | bandit         | confidence             | report only issues of a given confidence     |
 +----------------+------------------------+----------------------------------------------+
+| bandit         | -anything-other-       | Options pass to Bandit directly              |
++----------------+------------------------+----------------------------------------------+
 | pyright        | level                  | Minimum diagnostic level (error or warning)  |
 +----------------+------------------------+----------------------------------------------+
 | pyright        | project                | Path to location of configuration file       |

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -317,7 +317,7 @@ Search path: {search_path}, or in module 'prospector_profile_{module_name}'
         # global config, but this could be extended in the future
         return not self.config.no_external_config
 
-    def tool_options(self, tool_name: str) -> dict[str, str]:
+    def tool_options(self, tool_name: str) -> dict[str, Any]:
         tool = getattr(self.profile, tool_name, None)
         if tool is None:
             return {}

--- a/prospector/formatters/xunit.py
+++ b/prospector/formatters/xunit.py
@@ -1,4 +1,4 @@
-from xml.dom.minidom import Document
+from xml.dom.minidom import Document  # nosec
 
 from prospector.formatters.base import Formatter
 

--- a/prospector/tools/mccabe/__init__.py
+++ b/prospector/tools/mccabe/__init__.py
@@ -25,7 +25,7 @@ class McCabeTool(ToolBase):
 
         options = prospector_config.tool_options("mccabe")
         if "max-complexity" in options:
-            self.max_complexity = options["max-complexity"]  # type: ignore[assignment]
+            self.max_complexity = options["max-complexity"]
 
     def run(self, found_files: FileFinder) -> list[Message]:
         messages = []

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -65,7 +65,7 @@ class MypyTool(ToolBase):
     def configure(self, prospector_config: "ProspectorConfig", _: Any) -> None:
         options = prospector_config.tool_options("mypy")
 
-        self.use_dmypy = options.pop("use-dmypy", False)  # type: ignore[assignment]
+        self.use_dmypy = options.pop("use-dmypy", False)
 
         # For backward compatibility
         if "follow-imports" not in options:

--- a/prospector/tools/pyright/__init__.py
+++ b/prospector/tools/pyright/__init__.py
@@ -1,5 +1,5 @@
 import json
-import subprocess
+import subprocess  # nosec
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Optional
 


### PR DESCRIPTION
## Description

Be able to pass options to Bandit without using a specific configuration filename

## Motivation and Context

Profit on the profile's inheritance to be able to configure Bandit

## How Has This Been Tested?

On the Prospector code
