### PR TITLE
Add Ruff as supported tool

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -65,3 +65,12 @@ bandit:
   run: true
   disable:
   - B101 # Use of assert detected.
+
+ruff:
+  run: true
+  options:
+    fix: true
+  disable:
+    - E501 # line too long
+    - S101 # Use of assert detected
+    - SIM105 # suppressible-exception (slow code)

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -282,7 +282,7 @@ Individual Configuration Options
 
 Each tool can be individually configured with a section beginning with the tool name
 (in lowercase). Valid values are ``bandit``, ``dodgy``, ``frosted``, ``mccabe``, ``mypy``, ``pydocstyle``, ``pycodestyle``,
-``pyflakes``, ``pylint``, ``pyright``, ``pyroma`` and  ``vulture``.
+``pyflakes``, ``pylint``, ``pyright``, ``pyroma``,  ``vulture`` and ``ruff``.
 
 Enabling and Disabling Tools
 ............................
@@ -416,17 +416,26 @@ The available options are:
 +----------------+------------------------+----------------------------------------------+
 | pyright        | venv-path              | Directory that contains virtual environments |
 +----------------+------------------------+----------------------------------------------+
+| ruff           | -anything-             | Options pass to ruff as argument             |
+|                |                        | `True` => --<option>                         |
+|                |                        | `False` => ignoring                          |
+|                |                        | <string> => --<option>=<value>               |
+|                |                        | <list> => --<option>=<comma separated value> |
+|                |                        | <dict> => --<option>=<comma separated key>   |
+|                |                        |           if sub value is true               |
++----------------+------------------------+----------------------------------------------+
 
 See `bandit options`_ for more details
 
 See `pyright options`_ for more details
 
-
+See `ruff options`_ for more details
 
 .. _pylint options: https://pylint.readthedocs.io/en/latest/user_guide/run.html
 .. _bandit options: https://bandit.readthedocs.io/en/latest/config.html
 .. _mypy options: https://mypy.readthedocs.io/en/stable/command_line.html
 .. _pyright options: https://microsoft.github.io/pyright/#/command-line
+.. _ruff options: https://docs.astral.sh/ruff/configuration/#command-line-interface
 
 
 

--- a/docs/supported_tools.rst
+++ b/docs/supported_tools.rst
@@ -172,3 +172,14 @@ To install and use::
 
     pip install prospector[with_pyright]
     prospector --with-tool pyright
+
+
+`Ruff <https://docs.astral.sh/ruff/>`_
+``````````````````````````````````````
+
+An extremely fast Python linter, written in Rust.
+
+To install and use::
+
+    pip install prospector[with_ruff]
+    prospector --with-tool ruff

--- a/poetry.lock
+++ b/poetry.lock
@@ -1497,6 +1497,33 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "ruff"
+version = "0.7.1"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.7.1-py3-none-linux_armv6l.whl", hash = "sha256:cb1bc5ed9403daa7da05475d615739cc0212e861b7306f314379d958592aaa89"},
+    {file = "ruff-0.7.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:27c1c52a8d199a257ff1e5582d078eab7145129aa02721815ca8fa4f9612dc35"},
+    {file = "ruff-0.7.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:588a34e1ef2ea55b4ddfec26bbe76bc866e92523d8c6cdec5e8aceefeff02d99"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94fc32f9cdf72dc75c451e5f072758b118ab8100727168a3df58502b43a599ca"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:985818742b833bffa543a84d1cc11b5e6871de1b4e0ac3060a59a2bae3969250"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32f1e8a192e261366c702c5fb2ece9f68d26625f198a25c408861c16dc2dea9c"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:699085bf05819588551b11751eff33e9ca58b1b86a6843e1b082a7de40da1565"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:344cc2b0814047dc8c3a8ff2cd1f3d808bb23c6658db830d25147339d9bf9ea7"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4316bbf69d5a859cc937890c7ac7a6551252b6a01b1d2c97e8fc96e45a7c8b4a"},
+    {file = "ruff-0.7.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79d3af9dca4c56043e738a4d6dd1e9444b6d6c10598ac52d146e331eb155a8ad"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c5c121b46abde94a505175524e51891f829414e093cd8326d6e741ecfc0a9112"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8422104078324ea250886954e48f1373a8fe7de59283d747c3a7eca050b4e378"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:56aad830af8a9db644e80098fe4984a948e2b6fc2e73891538f43bbe478461b8"},
+    {file = "ruff-0.7.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:658304f02f68d3a83c998ad8bf91f9b4f53e93e5412b8f2388359d55869727fd"},
+    {file = "ruff-0.7.1-py3-none-win32.whl", hash = "sha256:b517a2011333eb7ce2d402652ecaa0ac1a30c114fbbd55c6b8ee466a7f600ee9"},
+    {file = "ruff-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f38c41fcde1728736b4eb2b18850f6d1e3eedd9678c914dede554a70d5241307"},
+    {file = "ruff-0.7.1-py3-none-win_arm64.whl", hash = "sha256:19aa200ec824c0f36d0c9114c8ec0087082021732979a359d6f3c390a6ff2a37"},
+    {file = "ruff-0.7.1.tar.gz", hash = "sha256:9d8a41d4aa2dad1575adb98a82870cf5db5f76b2938cf2206c22c940034a36f4"},
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -1817,13 +1844,14 @@ type = ["pytest-mypy"]
 
 [extras]
 with-bandit = ["bandit"]
-with-everything = ["bandit", "mypy", "pyright", "pyroma", "vulture"]
+with-everything = ["bandit", "mypy", "pyright", "pyroma", "ruff", "vulture"]
 with-mypy = ["mypy"]
 with-pyright = ["pyright"]
 with-pyroma = ["pyroma"]
+with-ruff = ["ruff"]
 with-vulture = ["vulture"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "de3329503e452b1ca74073fa9893ebfe6cb6812c92c6d7ace32fb5e46652df4e"
+content-hash = "5df048c7fdf414e2b3b27994066a91deffefd4352d929a783404bbbc1a5b043c"

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -312,6 +312,9 @@ Search path: {search_path}, or in module 'prospector_profile_{module_name}'
     def get_disabled_messages(self, tool_name: str) -> list[str]:
         return self.profile.get_disabled_messages(tool_name)
 
+    def get_enabled_messages(self, tool_name: str) -> list[str]:
+        return self.profile.get_enabled_messages(tool_name)
+
     def use_external_config(self, _: Any) -> bool:
         # Currently there is only one single global setting for whether to use
         # global config, but this could be extended in the future

--- a/prospector/formatters/pylint.py
+++ b/prospector/formatters/pylint.py
@@ -27,12 +27,24 @@ class PylintFormatter(SummaryFormatter):
             # prospector/configuration.py:65: [missing-docstring(missing-docstring), build_default_sources] \
             # Missing function docstring
 
-            template = "%(path)s:%(line)s: [%(code)s(%(source)s), %(function)s] %(message)s"
+            template_location = (
+                "%(path)s"
+                if message.location.line is None
+                else "%(path)s:%(line)s"
+                if message.location.character is None
+                else "%(path)s:%(line)s:%(character)s"
+            )
+            template_code = (
+                "%(code)s(%(source)s)" if message.location.function is None else "[%(code)s(%(source)s), %(function)s]"
+            )
+            template = f"{template_location}: {template_code}: %(message)s"
+
             output.append(
                 template
                 % {
                     "path": self._make_path(message.location),
                     "line": message.location.line,
+                    "character": message.location.character,
                     "source": message.source,
                     "code": message.code,
                     "function": message.location.function,

--- a/prospector/tools/__init__.py
+++ b/prospector/tools/__init__.py
@@ -69,6 +69,7 @@ TOOLS: dict[str, type[ToolBase]] = {
     "pyright": _optional_tool("pyright"),
     "mypy": _optional_tool("mypy"),
     "bandit": _optional_tool("bandit"),
+    "ruff": _optional_tool("ruff"),
 }
 
 

--- a/prospector/tools/ruff/__init__.py
+++ b/prospector/tools/ruff/__init__.py
@@ -1,0 +1,75 @@
+import json
+import subprocess  # nosec
+from typing import TYPE_CHECKING, Any
+
+from ruff.__main__ import find_ruff_bin
+
+from prospector.finder import FileFinder
+from prospector.message import Location, Message
+from prospector.tools.base import ToolBase
+
+if TYPE_CHECKING:
+    from prospector.config import ProspectorConfig
+
+
+class RuffTool(ToolBase):
+    def configure(self, prospector_config: "ProspectorConfig", _: Any) -> None:
+        self.ruff_bin = find_ruff_bin()
+        self.ruff_args = ["check", "--output-format=json"]
+
+        enabled = prospector_config.get_enabled_messages("ruff")
+        if enabled:
+            enabled_arg_value = ",".join(enabled)
+            self.ruff_args.append(f"--select={enabled_arg_value}")
+        disabled = prospector_config.get_disabled_messages("ruff")
+        if disabled:
+            disabled_arg_value = ",".join(disabled)
+            self.ruff_args.append(f"--ignore={disabled_arg_value}")
+
+        options = prospector_config.tool_options("ruff")
+        for key, value in options.items():
+            if value is True:
+                self.ruff_args.append(f"--{key}")
+            elif value is False:
+                pass
+            elif isinstance(value, list):
+                arg_value = ",".join(value)
+                self.ruff_args.append(f"--{key}={arg_value}")
+            # dict is like array but with a dict with true/false value to be able to merge profiles
+            elif isinstance(value, dict):
+                arg_value = ",".join(k for k, v in value.items() if v)
+                self.ruff_args.append(f"--{key}={arg_value}")
+            else:
+                self.ruff_args.append(f"--{key}={value}")
+
+    def run(self, found_files: FileFinder) -> list[Message]:
+        print([self.ruff_bin, *self.ruff_args])
+        messages = []
+        completed_process = subprocess.run(  # noqa: S603
+            [self.ruff_bin, *self.ruff_args, *found_files.python_modules], capture_output=True
+        )
+        for message in json.loads(completed_process.stdout):
+            sub_message = {}
+            if message.get("url"):
+                sub_message["See"] = message["url"]
+            if message.get("fix") and message["fix"].get("applicability"):
+                sub_message["Fix applicability"] = message["fix"]["applicability"]
+            message_str = message.get("message", "")
+            if sub_message:
+                message_str += f" [{', '.join(f'{k}: {v}' for k, v in sub_message.items())}]"
+
+            messages.append(
+                Message(
+                    "ruff",
+                    message.get("code") or "unknown",
+                    Location(
+                        message.get("filename") or "unknown",
+                        None,
+                        None,
+                        line=message.get("location", {}).get("row"),
+                        character=message.get("location", {}).get("column"),
+                    ),
+                    message_str,
+                )
+            )
+        return messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ vulture = {version = ">=1.5", optional = true}
 mypy = {version = ">=0.600", optional = true}
 pyright = {version = ">=1.1.3", optional = true}
 pyroma = {version = ">=2.4", optional = true}
+ruff = {version = "*", optional = true}
 
 [tool.poetry.extras]
 with_bandit = ["bandit"]
@@ -66,7 +67,8 @@ with_mypy = ["mypy"]
 with_pyright = ["pyright"]
 with_pyroma = ["pyroma"]
 with_vulture = ["vulture"]
-with_everything = ["bandit", "mypy", "pyright", "pyroma", "vulture"]
+with_ruff = ["ruff"]
+with_everything = ["bandit", "mypy", "pyright", "pyroma", "vulture", "ruff"]
 
 [tool.poetry.dev-dependencies]
 coveralls = "^3.3.1"

--- a/tests/tools/bandit/test_ruff_tool.py
+++ b/tests/tools/bandit/test_ruff_tool.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from prospector.config import ProspectorConfig
+from prospector.finder import FileFinder
+from prospector.tools.ruff import RuffTool
+
+
+class test_ruff_tool:
+    with patch("sys.argv", []):
+        config = ProspectorConfig()
+    ruff_tool = RuffTool()
+
+    found_files = FileFinder(Path(__file__).parent / "testpath/testfile.py")
+    ruff_tool.configure(config, found_files)
+    messages = ruff_tool.run(found_files)
+    assert {"S105", "S106", "S107"} == {message.code for message in messages}


### PR DESCRIPTION
## Description

Add Ruff as supported tool

I also modified the pylint output to:
- Avoid having a None in the message
- Add the character if available
- Be stronger
- Be more like the pylint output

And the profile merge to be able to better activate deactivate feature from inherited template, then I do a deep merge of the dictionaries that's in the option.

## Related Issue

Fix #601

## How Has This Been Tested?

On prospector code

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
