### PR TITLE
Fix path list in error

### DIFF
--- a/prospector/profiles/exceptions.py
+++ b/prospector/profiles/exceptions.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
+
 class ProfileNotFound(Exception):
-    def __init__(self, name: str, profile_path: str) -> None:
+    def __init__(self, name: str, profile_path: list[Path]) -> None:
         super().__init__()
         self.name = name
         self.profile_path = profile_path
@@ -7,7 +10,7 @@ class ProfileNotFound(Exception):
     def __repr__(self) -> str:
         return "Could not find profile {}; searched in {}".format(
             self.name,
-            ":".join(self.profile_path),
+            ":".join(map(str, self.profile_path)),
         )
 
 

--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -178,7 +178,7 @@ def _load_content(name_or_path: Union[str, Path], profile_path: list[Path]) -> d
         if optional:
             return {}
 
-        raise ProfileNotFound(str(name_or_path), str(profile_path))
+        raise ProfileNotFound(str(name_or_path), profile_path)
 
     with codecs.open(filename) as fct:
         try:


### PR DESCRIPTION
## Description

`prospector --profile inexisting` war returning
```
Failed to run:
Could not find profile 111.
Search path: [:P:o:s:i:x:P:a:t:h:(:':/:h:o:m:e:/:s:b:r:u:n:n:e:r:/:w:o:r:k:s:p:a:c:e:/:p:r:o:s:p:e:c:t:o:r:':):,: :P:o:s:i:x:P:a:t:h:(:':/:h:o:m:e:/:s:b:r:u:n:n:e:r:/:w:o:r:k:s:p:a:c:e:/:p:r:o:s:p:e:c:t:o:r:/:p:r:o:s:p:e:c:t:o:r:/:p:r:o:f:i:l:e:s:/:p:r:o:f:i:l:e:s:':):], or in module 'prospector_profile_inexisting'
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
