### PR TITLE
Fix blender when line is None

### DIFF
--- a/prospector/blender.py
+++ b/prospector/blender.py
@@ -88,8 +88,8 @@ def blend(messages: list[Message], blend_combos: Optional[list[list[tuple[str, s
     msgs_grouped: dict[Path, dict[int, list[Message]]] = defaultdict(lambda: defaultdict(list))
 
     for message in messages:
-        assert message.location.line is not None
-        msgs_grouped[message.location.path][message.location.line].append(
+        line = message.location.line
+        msgs_grouped[message.location.path][-1 if line is None else line].append(
             message,
         )
 


### PR DESCRIPTION
## Description

Currently, we can obtain this exceptions:

```
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repocjulckrl/py_env-python3/bin/prospector", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/.cache/pre-commit/repocjulckrl/py_env-python3/lib/python3.11/site-packages/prospector/run.py", line 200, in main
    prospector.execute()
  File "/home/runner/.cache/pre-commit/repocjulckrl/py_env-python3/lib/python3.11/site-packages/prospector/run.py", line 119, in execute
    messages = self.process_messages(found_files, messages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repocjulckrl/py_env-python3/lib/python3.11/site-packages/prospector/run.py", line 30, in process_messages
    messages = blender.blend(messages)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repocjulckrl/py_env-python3/lib/python3.11/site-packages/prospector/blender.py", line 91, in blend
    assert message.location.line is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Then fix it

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
