### PR TITLE
Fix Ruff on error

### DIFF
--- a/prospector/blender.py
+++ b/prospector/blender.py
@@ -85,11 +85,10 @@ def blend(messages: list[Message], blend_combos: Optional[list[list[tuple[str, s
     blend_combos = blend_combos or BLEND_COMBOS
 
     # group messages by file and then line number
-    msgs_grouped: dict[Path, dict[int, list[Message]]] = defaultdict(lambda: defaultdict(list))
+    msgs_grouped: dict[Optional[Path], dict[Optional[int], list[Message]]] = defaultdict(lambda: defaultdict(list))
 
     for message in messages:
-        line = message.location.line
-        msgs_grouped[message.location.path][-1 if line is None else line].append(
+        msgs_grouped[message.location.path][message.location.line].append(
             message,
         )
 

--- a/prospector/formatters/base.py
+++ b/prospector/formatters/base.py
@@ -28,7 +28,8 @@ class Formatter(ABC):
         raise NotImplementedError
 
     def _make_path(self, location: Location) -> Path:
-        return location.relative_path(self.paths_relative_to)
+        path_ = location.relative_path(self.paths_relative_to)
+        return Path() if path_ is None else path_
 
     def _message_to_dict(self, message: Message) -> dict[str, Any]:
         loc = {

--- a/prospector/formatters/grouped.py
+++ b/prospector/formatters/grouped.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from pathlib import Path
+from typing import Optional
 
 from prospector.formatters.text import TextFormatter
 from prospector.message import Message
@@ -15,10 +16,9 @@ class GroupedFormatter(TextFormatter):
             "",
         ]
 
-        groups: dict[Path, dict[int, list[Message]]] = defaultdict(lambda: defaultdict(list))
+        groups: dict[Path, dict[Optional[int], list[Message]]] = defaultdict(lambda: defaultdict(list))
 
         for message in self.messages:
-            assert message.location.line is not None
             groups[self._make_path(message.location)][message.location.line].append(message)
 
         for filename in sorted(groups.keys()):

--- a/prospector/formatters/pylint.py
+++ b/prospector/formatters/pylint.py
@@ -28,16 +28,26 @@ class PylintFormatter(SummaryFormatter):
             # Missing function docstring
 
             template_location = (
-                "%(path)s"
+                ""
+                if message.location.path is None
+                else "%(path)s"
                 if message.location.line is None
                 else "%(path)s:%(line)s"
                 if message.location.character is None
                 else "%(path)s:%(line)s:%(character)s"
             )
             template_code = (
-                "%(code)s(%(source)s)" if message.location.function is None else "[%(code)s(%(source)s), %(function)s]"
+                "(%(source)s)"
+                if message.code is None
+                else "%(code)s(%(source)s)"
+                if message.location.function is None
+                else "[%(code)s(%(source)s), %(function)s]"
             )
-            template = f"{template_location}: {template_code}: %(message)s"
+            template = (
+                f"{template_location}: {template_code}: %(message)s"
+                if template_location
+                else f"{template_code}: %(message)s"
+            )
 
             output.append(
                 template

--- a/prospector/message.py
+++ b/prospector/message.py
@@ -3,9 +3,11 @@ from typing import Optional, Union
 
 
 class Location:
+    _path: Optional[Path]
+
     def __init__(
         self,
-        path: Union[Path, str],
+        path: Optional[Union[Path, str]],
         module: Optional[str],
         function: Optional[str],
         line: Optional[int],
@@ -15,6 +17,8 @@ class Location:
             self._path = path.absolute()
         elif isinstance(path, str):
             self._path = Path(path).absolute()
+        elif path is None:
+            self._path = None
         else:
             raise ValueError
         self.module = module or None
@@ -23,13 +27,15 @@ class Location:
         self.character = None if character == -1 else character
 
     @property
-    def path(self) -> Path:
+    def path(self) -> Optional[Path]:
         return self._path
 
-    def absolute_path(self) -> Path:
+    def absolute_path(self) -> Optional[Path]:
         return self._path
 
-    def relative_path(self, root: Optional[Path]) -> Path:
+    def relative_path(self, root: Optional[Path]) -> Optional[Path]:
+        if self._path is None:
+            return None
         return self._path.relative_to(root) if root else self._path
 
     def __repr__(self) -> str:
@@ -46,6 +52,13 @@ class Location:
     def __lt__(self, other: "Location") -> bool:
         if not isinstance(other, Location):
             raise ValueError
+
+        if self._path is None and other._path is None:
+            return False
+        if self._path is None:
+            return True
+        if other._path is None:
+            return False
         if self._path == other._path:
             if self.line == other.line:
                 return (self.character or -1) < (other.character or -1)

--- a/prospector/postfilter.py
+++ b/prospector/postfilter.py
@@ -29,7 +29,7 @@ def filter_messages(filepaths: List[Path], messages: List[Message]) -> List[Mess
     filtered = []
     for message in messages:
         # first get rid of the pylint informational messages
-        relative_message_path = Path(message.location.path)
+        relative_message_path = message.location.path
 
         if message.source == "pylint" and message.code in (
             "suppressed-message",

--- a/prospector/tools/ruff/__init__.py
+++ b/prospector/tools/ruff/__init__.py
@@ -47,6 +47,16 @@ class RuffTool(ToolBase):
         completed_process = subprocess.run(  # noqa: S603
             [self.ruff_bin, *self.ruff_args, *found_files.python_modules], capture_output=True
         )
+        if not completed_process.stdout:
+            messages.append(
+                Message(
+                    "ruff",
+                    "",
+                    Location(None, None, None, None, None),
+                    completed_process.stderr.decode(),
+                )
+            )
+            return messages
         for message in json.loads(completed_process.stdout):
             sub_message = {}
             if message.get("url"):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -25,7 +25,6 @@ class LocationPathTest(TestCase):
 
     def test_bad_path_input(self):
         self.assertRaises(ValueError, Location, 3.2, "module", "func", 1, 2)
-        self.assertRaises(ValueError, Location, None, "module", "func", 1, 2)
 
 
 class LocationOrderTest(TestCase):


### PR DESCRIPTION
## Description

Currently, we get:
```
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repoi1wsp71_/py_env-python3/lib/python3.13/site-packages/prospector/run.py", line 87, in execute
    messages += tool.run(found_files)
                ~~~~~~~~^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repoi1wsp71_/py_env-python3/lib/python3.13/site-packages/prospector/tools/ruff/__init__.py", line 51, in run
    for message in json.loads(completed_process.stdout):
                   ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/json/decoder.py", line 344, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/json/decoder.py", line 362, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repoi1wsp71_/py_env-python3/bin/prospector", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/.cache/pre-commit/repoi1wsp71_/py_env-python3/lib/python3.13/site-packages/prospector/run.py", line 200, in main
    prospector.execute()
    ~~~~~~~~~~~~~~~~~~^^
  File "/home/runner/.cache/pre-commit/repoi1wsp71_/py_env-python3/lib/python3.13/site-packages/prospector/run.py", line 105, in execute
    raise FatalProspectorException(f"Tool {toolname} failed to run.") from ex
prospector.exceptions.FatalProspectorException: Tool ruff failed to run.
```

The new output with pylint output will be:
```
(ruff): error: unexpected argument '--unsafe-fix' found

  tip: a similar argument exists: '--unsafe-fixes'

Usage: ruff check <FILES|--fix|--no-fix|--unsafe-fixes|--no-unsafe-fixes|--show-fixes|--no-show-fixes|--diff|--watch|--fix-only|--no-fix-only|--ignore-noqa|--output-format <OUTPUT_FORMAT>|--output-file <OUTPUT_FILE>|--target-version <TARGET_VERSION>|--preview|--no-preview|--select <RULE_CODE>|--ignore <RULE_CODE>|--extend-select <RULE_CODE>|--extend-ignore <RULE_CODE>|--per-file-ignores <PER_FILE_IGNORES>|--extend-per-file-ignores <EXTEND_PER_FILE_IGNORES>|--exclude <FILE_PATTERN>|--extend-exclude <FILE_PATTERN>|--fixable <RULE_CODE>|--unfixable <RULE_CODE>|--extend-fixable <RULE_CODE>|--extend-unfixable <RULE_CODE>|--respect-gitignore|--no-respect-gitignore|--force-exclude|--no-force-exclude|--line-length <LINE_LENGTH>|--dummy-variable-rgx <DUMMY_VARIABLE_RGX>|--no-cache|--cache-dir <CACHE_DIR>|--stdin-filename <STDIN_FILENAME>|--extension <EXTENSION>|--exit-zero|--exit-non-zero-on-fix|--statistics|--add-noqa|--show-files|--show-settings>

For more information, try '--help'.

Check Information
=================
         Started: 2024-11-14 09:55:33.038829
        Finished: 2024-11-14 09:55:33.161889
      Time Taken: 0.12 seconds
       Formatter: pylint
        Profiles: .prospector.yaml, utils:base, strictness_veryhigh, utils:no-design-checks, utils:fix, utils:unsafe, utils:c2cwsgiutils, duplicated, duplicated:black, duplicated:isort, duplicated:pyupgrade, duplicated:pylint, duplicated:docformatter, duplicated:autoflake, duplicated:pydocstyle, no_doc_warnings, no_member_warnings, no_test_warnings
      Strictness: from profile
  Libraries Used: 
       Tools Run: ruff
  Messages Found: 1
```

## How Has This Been Tested?

Tested on error with all outputs!

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
