### PR TITLE
Added pylint-parseable formatter

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -19,6 +19,7 @@ Contributors
 * Ian Lee (`@IanLee1521 <https://github.com/IanLee1521>`_)
 * Ian Stapleton Cordasco (`@sigmavirus24 <https://github.com/sigmavirus24>`_)
 * iderr (`@IDerr <https://github.com/IDerr>`_)
+* Joa Cortez (`@joacortez <https://github.com/joacortez>`_)
 * Joe Wallis (`@Peilonrayz <https://github.com/Peilonrayz>`_)
 * Jon Parise (`@jparise <https://github.com/jparise>`_)
 * Kristian Glass (`@doismellburning <https://github.com/doismellburning>`_)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,31 +29,39 @@ Output Format
 
 The default output format of ``prospector`` is designed to be human readable. You can change the output format using the ``--output-format`` or ``-o`` flags - for example, to get the output in JSON form you can use the ``--output-format json``.
 
-+-------------+----------------------------------------------------------------------------+
-| Format Name | Notes                                                                      |
-+=============+============================================================================+
-| ``emacs``   | | Support for emacs compilation output mode, see `issue_16`_.              |
-+-------------+----------------------------------------------------------------------------+
-| ``vscode``  | | Support for `vscode_python_plugin`_                                      |
-+-------------+----------------------------------------------------------------------------+
-| ``grouped`` | | Similar to ``text``, but groups all message on the same line together    |
-|             | | rather than having a separate entry per message.                         |
-+-------------+----------------------------------------------------------------------------+
-| ``pylint``  | | Produces output in the same style as ``pylint --parseable``. This should |
-|             | | allow ``prospector`` to be used as a drop-in replacement for any tools   |
-|             | | which parse ``pylint`` output. The one minor difference is that the      |
-|             | | output includes the name of the tool which generated the error as well   |
-|             | | as the error code.                                                       |
-+-------------+----------------------------------------------------------------------------+
-| ``json``    | | Produces a structured, parseable output of the messages and summary. See |
-|             | | below for more information about the structure.                          |
-+-------------+----------------------------------------------------------------------------+
-| ``yaml``    | | Same as JSON except produces YAML output.                                |
-+-------------+----------------------------------------------------------------------------+
-| ``xunit``   | | Same as JSON except produces xunit compatible XML output.                |
-+-------------+----------------------------------------------------------------------------+
-| ``text``    | | The default output format, a simple human readable format.               |
-+-------------+----------------------------------------------------------------------------+
++----------------------+----------------------------------------------------------------------------+
+|     Format Name      | Notes                                                                      |
++======================+============================================================================+
+| ``emacs``            | | Support for emacs compilation output mode, see `issue_16`_.              |
++----------------------+----------------------------------------------------------------------------+
+| ``vscode``           | | Support for `vscode_python_plugin`_                                      |
++----------------------+----------------------------------------------------------------------------+
+| ``grouped``          | | Similar to ``text``, but groups all message on the same line together    |
+|                      | | rather than having a separate entry per message.                         |
++----------------------+----------------------------------------------------------------------------+
+| ``pylint``           | | Produces output in the same style as ``pylint`` using the following      |
+|                      | | format:                                                                  |
+|                      | | ``{path}:{line}:{character}: [{msg_id}({symbol}), {obj}] {msg}``.        |
+|                      | | The output includes the name of the tool which generated the error as    |
+|                      | | as well as the error code.                                               |
++----------------------+----------------------------------------------------------------------------+
+| ``pylint_parseable`` | | Produces output in the same style as ``pylint --parseable``. The         |
+|                      | | format is ``{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}``.          |
+|                      | | The difference is that this option excludes the column. This should      |
+|                      | | allow ``prospector`` to be used as a drop-in replacement for any tools   |
+|                      | | which parse ``pylint --parseable`` output. The one minor difference is   |
+|                      | | that the output includes the name of the tool which generated the error  |
+|                      | | as well as the error code.                                               |
++----------------------+----------------------------------------------------------------------------+
+| ``json``             | | Produces a structured, parseable output of the messages and summary. See |
+|                      | | below for more information about the structure.                          |
++----------------------+----------------------------------------------------------------------------+
+| ``yaml``             | | Same as JSON except produces YAML output.                                |
++----------------------+----------------------------------------------------------------------------+
+| ``xunit``            | | Same as JSON except produces xunit compatible XML output.                |
++----------------------+----------------------------------------------------------------------------+
+| ``text``             | | The default output format, a simple human readable format.               |
++----------------------+----------------------------------------------------------------------------+
 
 
 If your code uses frameworks and libraries

--- a/prospector/formatters/__init__.py
+++ b/prospector/formatters/__init__.py
@@ -1,4 +1,4 @@
-from . import emacs, grouped, json, pylint, text, vscode, xunit, yaml
+from . import emacs, grouped, json, pylint, pylint_parseable, text, vscode, xunit, yaml
 from .base import Formatter
 
 __all__ = ("FORMATTERS", "Formatter")
@@ -11,6 +11,7 @@ FORMATTERS: dict[str, type[Formatter]] = {
     "emacs": emacs.EmacsFormatter,
     "yaml": yaml.YamlFormatter,
     "pylint": pylint.PylintFormatter,
+    "pylint_parseable": pylint_parseable.PylintParseableFormatter,
     "xunit": xunit.XunitFormatter,
     "vscode": vscode.VSCodeFormatter,
 }

--- a/prospector/formatters/pylint_parseable.py
+++ b/prospector/formatters/pylint_parseable.py
@@ -6,7 +6,7 @@ from prospector.formatters.base_summary import SummaryFormatter
 
 class PylintParseableFormatter(SummaryFormatter):
     """
-    This formatter outputs messages in the same way as pylint -f parseable , which is used by several
+    This formatter outputs messages in the same way as `pylint --output-format=parseable`, which is used by several
     tools to parse pylint output. This formatter is therefore a compatibility shim between tools built
     on top of pylint and prospector itself.
     """

--- a/prospector/formatters/pylint_parseable.py
+++ b/prospector/formatters/pylint_parseable.py
@@ -4,7 +4,7 @@ import re
 from prospector.formatters.base_summary import SummaryFormatter
 
 
-class PylintFormatter(SummaryFormatter):
+class PylintParseableFormatter(SummaryFormatter):
     """
     This formatter outputs messages in the same way as pylint -f parseable , which is used by several
     tools to parse pylint output. This formatter is therefore a compatibility shim between tools built
@@ -23,8 +23,8 @@ class PylintFormatter(SummaryFormatter):
                 header = f"************* Module {module_name}"
                 output.append(header)
 
-            #   ={path}:{line}:{character}: [{msg_id}({symbol}), {obj}] {msg}
-            # prospector/configuration.py:65:1: [missing-docstring(missing-docstring), build_default_sources] \
+            #   ={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+            # prospector/configuration.py:65: [missing-docstring(missing-docstring), build_default_sources] \
             # Missing function docstring
 
             template_location = (
@@ -33,8 +33,6 @@ class PylintFormatter(SummaryFormatter):
                 else "%(path)s"
                 if message.location.line is None
                 else "%(path)s:%(line)s"
-                if message.location.character is None
-                else "%(path)s:%(line)s:%(character)s"
             )
             template_code = (
                 "(%(source)s)"
@@ -54,7 +52,6 @@ class PylintFormatter(SummaryFormatter):
                 % {
                     "path": self._make_path(message.location),
                     "line": message.location.line,
-                    "character": message.location.character,
                     "source": message.source,
                     "code": message.code,
                     "function": message.location.function,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a new output format called `pylint-parseable` that follows this format: `{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}`.
Updated a comment in the existing pylint formatter to reflect the actual formatting generated by the formatter and updated the docs accordingly.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When trying to integrate prospector into a CI/CD tool I realized that the pylint output does not follow the same output format as when using `pylint --output-format=parseable` (see [Pylint 3.3.3 Documentation](https://pylint.readthedocs.io/en/stable/user_guide/usage/output.html) The existing format includes the character in the output which makes it difficult for it to be used as a drop-in-replacement. I added a new formatter that uses the format mentioned in the docs. I added a new formatter to avoid make a breaking change.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since this does not affect other areas it was only tested using some existing python projects to test the output.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
