### PR TITLE
Better noqa interpretation

### DIFF
--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -1,7 +1,7 @@
 Profiles / Configuration
 ========================
 
-The behaviour of prospector can be configured by creating a profile. A profile is
+The behavior of prospector can be configured by creating a profile. A profile is
 a YAML file containing several sections as described below.
 
 Prospector will search for a ``.prospector.yaml`` file (and `several others`_) in the path that it is checking.
@@ -120,8 +120,8 @@ If creating your own profile, you can use the ``strictness`` like so::
 
     strictness: medium
 
-Valid values are 'verylow', 'low', 'medium' (the default), 'high' and 'veryhigh'. If you don't specify a
-strictness value, then the default of 'medium' will be used. To avoid using any of Prospector's default
+Valid values are ``verylow``, ``low``, ``medium`` (the default), ``high`` and ``veryhigh``. If you don't specify a
+strictness value, then the default of ``medium`` will be used. To avoid using any of Prospector's default
 strictness profiles, set ``strictness: none``.
 
 
@@ -172,7 +172,7 @@ but you can turn it on using the ``--member-warnings`` flag or in a profile::
 Libraries Used and Autodetect
 .............................
 
-Prospector will adjust the behaviour of the underlying tools based on the libraries that your project
+Prospector will adjust the behavior of the underlying tools based on the libraries that your project
 uses. If you use Django, for example, the `pylint-django <https://github.com/PyCQA/pylint-django>`_ plugin
 will be loaded. This will happen automatically.
 
@@ -274,7 +274,6 @@ Max Line Length
 This general option, provides a way to select maximum line length allowed.
 
 .. Note:: This general option overrides and takes precedence over same option in a particular tool (pycodestyle or pylint)
-
 
 
 Individual Configuration Options

--- a/docs/suppression.rst
+++ b/docs/suppression.rst
@@ -38,5 +38,9 @@ prospector::
 ----------
 
 A comment of ``noqa`` is used by `pycodestyle` and `pyflakes` when ignoring all errors on a certain
-line. If Prospector encounters a ``# noqa`` comment it will suppress any error from any tool
+line.
+
+If Prospector encounters a ``# noqa`` comment it will suppress any error from any tool
 including ``pylint`` and others such as ``dodgy``.
+
+If Prospector encounters a ``# noqa: <code>`` comment it will suppress the error with the given code.

--- a/prospector/blender_combinations.yaml
+++ b/prospector/blender_combinations.yaml
@@ -277,6 +277,11 @@ combinations:
   - - pep257: D103
     - pydocstyle: D103
     - pylint: missing-docstring
+
   - - pylint: singleton-comparison
     - pep8: E711
     - pycodestyle: E711
+
+  - - pylint: subprocess-run-check
+    - bandit: B603
+    - ruff: S603

--- a/prospector/postfilter.py
+++ b/prospector/postfilter.py
@@ -48,9 +48,14 @@ def filter_messages(filepaths: list[Path], messages: list[Message]) -> list[Mess
         if (
             relative_message_path in messages_to_ignore
             and message.location.line in messages_to_ignore[relative_message_path]
-            and message.code in messages_to_ignore[relative_message_path][message.location.line]
         ):
-            continue
+            matched = False
+            for ignore in messages_to_ignore[relative_message_path][message.location.line]:
+                if (ignore.source is None or message.source == ignore.source) and message.code in ignore.code:
+                    matched = True
+                    continue
+            if matched:
+                continue
 
         # otherwise this message was not filtered
         filtered.append(message)

--- a/prospector/tools/ruff/__init__.py
+++ b/prospector/tools/ruff/__init__.py
@@ -44,7 +44,7 @@ class RuffTool(ToolBase):
 
     def run(self, found_files: FileFinder) -> list[Message]:
         messages = []
-        completed_process = subprocess.run(  # noqa: S603
+        completed_process = subprocess.run(  # noqa
             [self.ruff_bin, *self.ruff_args, *found_files.python_modules], capture_output=True
         )
         if not completed_process.stdout:

--- a/tests/suppression/test_suppression.py
+++ b/tests/suppression/test_suppression.py
@@ -14,17 +14,32 @@ class SuppressionTest(unittest.TestCase):
 
     def test_ignore_file(self):
         file_contents = self._get_file_contents("test_ignore_file/test.py")
-        whole_file, _ = get_noqa_suppressions(file_contents)
+        whole_file, _, _ = get_noqa_suppressions(file_contents)
         self.assertTrue(whole_file)
 
     def test_ignore_lines(self):
         file_contents = self._get_file_contents("test_ignore_lines/test.py")
-        _, lines = get_noqa_suppressions(file_contents)
-        self.assertSetEqual({1, 2, 3}, lines)
+        _, lines, messages_to_ignore = get_noqa_suppressions(file_contents)
+        self.assertSetEqual({1, 2, 3, 4}, lines)
+
+        assert set(messages_to_ignore.keys()) == {6, 7, 8}
+        l6 = messages_to_ignore[6].pop()
+        assert l6.source is None
+        assert l6.code == "code"
+        l7 = messages_to_ignore[7].pop()
+        assert l7.source is None
+        assert l7.code == "code"
+        l8_sorted = sorted(messages_to_ignore[8], key=lambda x: x.code)
+        l8a = l8_sorted.pop()
+        assert l8a.source is None
+        assert l8a.code == "code2"
+        l8a = l8_sorted.pop()
+        assert l8a.source is None
+        assert l8a.code == "code1"
 
     def test_ignore_enum_error(self):
         file_contents = self._get_file_contents("test_ignore_enum/test.py")
-        _, lines = get_noqa_suppressions(file_contents)
+        _, lines, _ = get_noqa_suppressions(file_contents)
         self.assertSetEqual({5}, lines)
 
     def test_filter_messages(self):

--- a/tests/suppression/testdata/test_ignore_lines/test.py
+++ b/tests/suppression/testdata/test_ignore_lines/test.py
@@ -1,3 +1,8 @@
 import collections  # NOQA
 import os  # noqa
 import tempfile  # noqa
+import test  # noqa # test
+import test  # noqa test # test
+import test  # noqa: code
+import test  # noqa: code # test
+import test  # noqa: code1,code2 # test


### PR DESCRIPTION
## Description

- To completely ignore a line the `# noqa` should be alone
- To ignore a code we can use `# noqa: <code>` ad ruff do
- To ignore a code from a certain source use `# noqa: <source>.<code>`, this will also create an error if the ignored is not used.

Alternative of #714

## Related Issue


## Motivation and Context

- Be compatible with Ruff
- Have more control on message to be ignored
- Be notified on used ignore

## How Has This Been Tested?

Test added

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


