### PR TITLE
Remove unexisting Ruff code

### DIFF
--- a/prospector/blender_combinations.yaml
+++ b/prospector/blender_combinations.yaml
@@ -23,7 +23,6 @@ combinations:
     - pycodestyle: E901
     - mccabe: MC0000
     - frosted: E402
-    - ruff: F999
 
   - # Undefined local variable
     - pylint: undefined-variable


### PR DESCRIPTION
## Description

The Ruff code F999 didn't exist, removing

See: https://docs.astral.sh/ruff/rules/
