### PR TITLE
Delete long_path_not_a_venv since not necessary

### DIFF
--- a/tests/finder/testdata/venvs/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv_long_path_not_a_v/README.txt
+++ b/tests/finder/testdata/venvs/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv/long_path_not_a_venv_long_path_not_a_v/README.txt
@@ -1,1 +1,0 @@
-This file is only here to ensure that the parent directory is present in Git checkouts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cloning on Windows/using pre-commit hook results in an error for long filename (#744) in `tests/finder/testdata/venvs/long_path_not_a_venv/...`. Also tests failed for Windows.
Configuring git with `git config --system core.longpaths true` solves the problem for cloning, it will however not solve the usage as a pre-commit hook.

## Motivation and Context
For testing pathutils the [current Test](https://github.com/prospector-dev/prospector/blob/master/tests/finder/test_pathutils.py#L30-L40) does not use the folder in testdata (also due to a typo in [L36](https://github.com/prospector-dev/prospector/blob/master/tests/finder/test_pathutils.py#L36) _"is_a_venv"_). The path is just passed to the _is_virtualenv_ method. Therefore i suggest to just delete the **long_path_not_a_venv** and its subfolders.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
