### PR TITLE
[poetry] Fix most deprecations without affecting the dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2069,4 +2069,4 @@ with-vulture = ["vulture"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "9a4702a1b631647a5a46eba07dc4c871f112fc066956db248887d3cd79855411"
+content-hash = "b820e3754e13f66a07c5b24135ca894c525de159df424ae78d4cb7ca9a847255"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
 ]
+requires-python = ">=3.9"
 
 [project.scripts]
 prospector = "prospector.run:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
 ]
 requires-python = ">=3.9"
+dynamic = ["dependencies"]
 
 [project.scripts]
 prospector = "prospector.run:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,20 @@
-[tool.poetry]
+[project]
 name = "prospector"
 version = "1.16.1"
 description = "Prospector is a tool to analyse Python code by aggregating the result of other tools."
-authors = ["Carl Crowder <git@carlcrowder.com>"]
-maintainers = ["Carl Crowder <git@carlcrowder.com>",
-               "Carlos Coelho <carlospecter@gmail.com>",
-               "Pierre Sassoulas <pierre.sassoulas@gmail.com>",
-               "Stéphane Brunner <stephane.brunner@gmail.com>"]
+authors = [
+    {name = "Carl Crowder", email = "git@carlcrowder.com"}
+]
+maintainers = [
+    {name = "Carl Crowder", email = "git@carlcrowder.com"},
+    {name = "Carlos Coelho", email = "carlospecter@gmail.com"},
+    {name = "Pierre Sassoulas", email = "pierre.sassoulas@gmail.com"},
+    {name = "Stéphane Brunner", email = "stephane.brunner@gmail.com"}
+]
 readme = "README.rst"
-homepage = "http://prospector.readthedocs.io"
-repository = "https://github.com/PyCQA/prospector"
+urls."Bug Tracker" = "https://github.com/prospector-dev/prospector/issues"
+urls."homepage" = "http://prospector.readthedocs.io"
+urls."repository" = "https://github.com/prospector-dev/prospector"
 keywords = ["pylint", "prospector", "static code analysis"]
 license = "GPLv2+"
 classifiers = [
@@ -25,6 +30,11 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
 ]
+
+[project.scripts]
+prospector = "prospector.run:main"
+
+[tool.poetry]
 # The format is a workaround aganst https://github.com/python-poetry/poetry/issues/9961
 packages = [
   { include = "prospector/", format = ["sdist"] }
@@ -33,9 +43,6 @@ include = [
   "prospector/blender_combinations.yaml",
   "prospector/profiles/profiles/*.yaml",
 ]
-
-[tool.poetry.scripts]
-prospector = 'prospector.run:main'
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
In order to be able to track where the cryptography dependency is taken I need to be able to use tool I know better than poetry and so making the pyproject.toml more normalized is helpful. In order to do that I start by fixing the output of `poetry check`.

Before:
```
Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.
Warning: [tool.poetry.version] is set but 'version' is not in [project.dynamic]. If it is static use [project.version]. If it is dynamic, add 'version' to [project.dynamic].
If you want to set the version dynamically via `poetry build --local-version` or you are using a plugin, which sets the version dynamically, you should define the version in [tool.poetry] and add 'version' to [project.dynamic].
Warning: [tool.poetry.description] is deprecated. Use [project.description] instead.
Warning: [tool.poetry.readme] is set but 'readme' is not in [project.dynamic]. If it is static use [project.readme]. If it is dynamic, add 'readme' to [project.dynamic].
If you want to define multiple readmes, you should define them in [tool.poetry] and add 'readme' to [project.dynamic].
Warning: [tool.poetry.license] is deprecated. Use [project.license] instead.
Warning: [tool.poetry.authors] is deprecated. Use [project.authors] instead.
Warning: [tool.poetry.maintainers] is deprecated. Use [project.maintainers] instead.
Warning: [tool.poetry.keywords] is deprecated. Use [project.keywords] instead.
Warning: [tool.poetry.classifiers] is set but 'classifiers' is not in [project.dynamic]. If it is static use [project.classifiers]. If it is dynamic, add 'classifiers' to [project.dynamic].
ATTENTION: Per default Poetry determines classifiers for supported Python versions and license automatically. If you define classifiers in [project], you disable the automatic enrichment. In other words, you have to define all classifiers manually. If you want to use Poetry's automatic enrichment of classifiers, you should define them in [tool.poetry] and add 'classifiers' to [project.dynamic].
Warning: [tool.poetry.homepage] is deprecated. Use [project.urls] instead.
Warning: [tool.poetry.repository] is deprecated. Use [project.urls] instead.
Warning: [tool.poetry.extras] is deprecated. Use [project.optional-dependencies] instead.
Warning: Defining console scripts in [tool.poetry.scripts] is deprecated. Use [project.scripts] instead. ([tool.poetry.scripts] should only be used for scripts of type 'file').
```
After:
```
Warning: [tool.poetry.extras] is deprecated. Use [project.optional-dependencies] instead.
```
Those last changes are what I actually need but they are going to change the dependencies used so let's do that in another MR.