### PR TITLE
Remove Prospector --zero-exit argument

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-      - run: pip install pre-commit .[with_everything]
+      - run: pip install pre-commit .[with_everything] types-PyYAML
 
       - uses: actions/cache@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,14 +60,12 @@ repos:
         require_serial: true
         verbose: true
         additional_dependencies:
-          # the following are needed to run mypy successfully in the pre-commit virtualenv
-          - types-setuptools
+          # the following are needed to run mypy.
           - types-PyYAML
         args:
-          - --zero-exit
           - --output-format=text
         exclude: |-
           (?x)^(
-            tests/suppression/testdata/.*
-            |tests/tools/vulture/testpath/testfile\.py
+            tests/.*
+            |docs/conf\.py
           )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,10 +62,12 @@ repos:
         additional_dependencies:
           # the following are needed to run mypy.
           - types-PyYAML
-        args:
-          - --output-format=text
         exclude: |-
           (?x)^(
-            tests/.*
+            tests/.*/testdata/.*
+            |tests/tools/.*/testpath/.*
+            |tests/tools/pylint/pylint_configs/.*
+            |tests/tools/pylint/test_no_init_found/.*
+            |tests/is_python/scrypt.*
             |docs/conf\.py
           )$

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -7,7 +7,7 @@ from prospector.finder import FileFinder
 from ..utils import patch_execution
 
 
-def test_relative_ignores():
+def test_relative_ignores() -> None:
     """
     Tests that if 'ignore-paths: something' is set, then it is ignored; that
     is, paths relative to the working directory should be ignored too
@@ -19,7 +19,7 @@ def test_relative_ignores():
         assert len(files.python_modules) == 2
 
 
-def test_determine_ignores_all_str():
+def test_determine_ignores_all_str() -> None:
     with patch_execution("-P", "prospector-str-ignores", set_cwd=Path(__file__).parent):
         config = ProspectorConfig()
     assert len(config.ignores) > 0
@@ -30,7 +30,7 @@ def test_determine_ignores_all_str():
         assert compiled_ignored_path in config.ignores
 
 
-def test_determine_ignores_containing_int_values_wont_throw_attr_exc():
+def test_determine_ignores_containing_int_values_wont_throw_attr_exc() -> None:
     with patch_execution("-P", "prospector-int-ignores", set_cwd=Path(__file__).parent):
         config = ProspectorConfig()
     assert len(config.ignores) > 0

--- a/tests/config/test_datatype.py
+++ b/tests/config/test_datatype.py
@@ -8,7 +8,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "linux")
     @patch("os.path.sep", "/")
     @patch("os.path.altsep", None)
-    def test_sanitize_rel_path_colon_posix(self):
+    def test_sanitize_rel_path_colon_posix(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit:./test-results.xml"),
@@ -18,7 +18,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "linux")
     @patch("os.path.sep", "/")
     @patch("os.path.altsep", None)
-    def test_sanitize_rel_path_semicolon_posix(self):
+    def test_sanitize_rel_path_semicolon_posix(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit;./test-results.xml"),
@@ -28,7 +28,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_rel_path_colon_windows(self):
+    def test_sanitize_rel_path_colon_windows(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit:.\\test-results.xml"),
@@ -38,7 +38,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_rel_path_semicolon_windows(self):
+    def test_sanitize_rel_path_semicolon_windows(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit;.\\test-results.xml"),
@@ -48,7 +48,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "linux")
     @patch("os.path.sep", "/")
     @patch("os.path.altsep", None)
-    def test_sanitize_abs_path_colon_posix(self):
+    def test_sanitize_abs_path_colon_posix(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit:/home/test-results.xml"),
@@ -58,7 +58,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "linux")
     @patch("os.path.sep", "/")
     @patch("os.path.altsep", None)
-    def test_sanitize_abs_path_semicolon_posix(self):
+    def test_sanitize_abs_path_semicolon_posix(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit;/home/test-results.xml"),
@@ -68,7 +68,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_abs_path_colon_windows(self):
+    def test_sanitize_abs_path_colon_windows(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit:C:\\testResults\\test-results.xml"),
@@ -78,7 +78,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_abs_path_semicolon_windows(self):
+    def test_sanitize_abs_path_semicolon_windows(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit;C:\\testResults\\test-results.xml"),
@@ -88,7 +88,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_abs_path_colon_windows_alternate(self):
+    def test_sanitize_abs_path_colon_windows_alternate(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit:C:/testResults/test-results.xml"),
@@ -98,7 +98,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_abs_path_semicolon_windows_alternate(self):
+    def test_sanitize_abs_path_semicolon_windows_alternate(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit;C:/testResults/test-results.xml"),
@@ -108,7 +108,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "linux")
     @patch("os.path.sep", "/")
     @patch("os.path.altsep", None)
-    def test_sanitize_abs_rel_path_colon_posix(self):
+    def test_sanitize_abs_rel_path_colon_posix(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit:/home/test-results.xml:./test-results.xml"),
@@ -118,7 +118,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "linux")
     @patch("os.path.sep", "/")
     @patch("os.path.altsep", None)
-    def test_sanitize_abs_rel_path_semicolon_posix(self):
+    def test_sanitize_abs_rel_path_semicolon_posix(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit;/home/test-results.xml;./test-results.xml"),
@@ -128,7 +128,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_abs_rel_path_colon_windows(self):
+    def test_sanitize_abs_rel_path_colon_windows(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit:C:\\home\\test-results.xml:.\\test-results.xml"),
@@ -138,7 +138,7 @@ class TestOutputChoice(TestCase):
     @patch("sys.platform", "win32")
     @patch("os.path.sep", "\\")
     @patch("os.path.altsep", "/")
-    def test_sanitize_abs_rel_path_semicolon_windows(self):
+    def test_sanitize_abs_rel_path_semicolon_windows(self) -> None:
         output_choice = OutputChoice(["xunit"])
         self.assertEqual(
             output_choice.sanitize("xunit;C:\\home\\test-results.xml;.\\test-results.xml"),

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -18,7 +18,7 @@ from ..utils import patch_cli, patch_cwd, patch_execution
 TEST_DATA = Path(__file__).parent / "testdata"
 
 
-def test_non_subpath():
+def test_non_subpath() -> None:
     """
     Create a temporary directory faaar away from the CWD when running, ensure prospector can run
     """
@@ -32,7 +32,7 @@ def test_non_subpath():
         shutil.rmtree(tempdir)
 
 
-def test_ignored():
+def test_ignored() -> None:
     workdir = TEST_DATA / "ignore_test"
     with patch_execution("--profile", "profile.yml", str(workdir), set_cwd=workdir):
         config = ProspectorConfig()
@@ -44,7 +44,7 @@ def test_ignored():
         assert msgs[0].location.module == "pkg1.pkg2.pkg3.broken"
 
 
-def test_total_errors():
+def test_total_errors() -> None:
     # There are 5 python files, all with the same error
     # Some are in sub-packages, one in a directory without an __init__
     # All should be found and exactly 1 error per file found
@@ -65,7 +65,7 @@ def test_total_errors():
     assert len(message_locs) == 0
 
 
-def test_relative_path_specified():
+def test_relative_path_specified() -> None:
     """
     This test was to fix `prospector .` returning different results to `prospector ../prospector`
     (when running inside the prospector checkout

--- a/tests/finder/test_filefinder.py
+++ b/tests/finder/test_filefinder.py
@@ -7,7 +7,7 @@ from .utils import TEST_DATA
 
 
 class TestFileFinder(TestCase):
-    def test_python_in_normal_dir(self):
+    def test_python_in_normal_dir(self) -> None:
         """
         This test is to find packages and files when given a directory which
         is not itself a python module but contains python modules
@@ -19,7 +19,7 @@ class TestFileFinder(TestCase):
         self.assertEqual("__init__.py", found[0].name)
         self.assertEqual("package2", found[0].parent.name)
 
-    def test_directory_with_modules(self):
+    def test_directory_with_modules(self) -> None:
         """
         Tests a non-module directory containing python modules finds all modules and
         files correctly
@@ -35,7 +35,7 @@ class TestFileFinder(TestCase):
         self.assertEqual(4, len(finder.python_packages))
         self.assertTrue(all(p.is_absolute() for p in finder.python_packages))
 
-    def test_package_finder(self):
+    def test_package_finder(self) -> None:
         """
         Checks that packages are found correctly and all - including subpackages if asked - are listed
         """
@@ -48,7 +48,7 @@ class TestFileFinder(TestCase):
         finder = FileFinder(TEST_DATA / "test4")
         self.assertEqual(3, len(finder.python_packages))
 
-    def test_subdirectories_omitted_if_parent_excluded(self):
+    def test_subdirectories_omitted_if_parent_excluded(self) -> None:
         """
         Verifies that if the directory "b" in "a/b/c/d" is ignored, then so are all children
         """
@@ -58,7 +58,7 @@ class TestFileFinder(TestCase):
         self.assertNotIn(lvl2, finder.directories)
         self.assertNotIn(lvl2, finder.python_modules)
 
-    def test_multiple_search_directories(self):
+    def test_multiple_search_directories(self) -> None:
         """
         The other tests only gave the finder one directory - this test gives it more,
         and checks there are no duplicates
@@ -83,13 +83,13 @@ class TestFileFinder(TestCase):
         # note: 10 including the 'test1' and 'test3' directories themselves, which contain 8 in total
         self.assertEqual(10, len(dirs))
 
-    def test_non_existent_path(self):
+    def test_non_existent_path(self) -> None:
         """
         Checks that the finder can cleanly handle being given paths that do not exist
         """
         self.assertRaises(FileNotFoundError, FileFinder, TEST_DATA / "does_not_exist")
 
-    def test_exclusion_filters(self):
+    def test_exclusion_filters(self) -> None:
         """
         Checks that paths excluded by filters are not returned in lists
         """
@@ -104,7 +104,7 @@ class TestFileFinder(TestCase):
         # exclude anything under 'package1'
         pkg1 = Path(TEST_DATA / "test1" / "package1")
 
-        def exclude(p: Path):
+        def exclude(p: Path) -> bool:
             return "package1" in p.parts
 
         finder = FileFinder(TEST_DATA / "test1", exclusion_filters=[exclude])

--- a/tests/finder/test_pathutils.py
+++ b/tests/finder/test_pathutils.py
@@ -7,27 +7,27 @@ from .utils import TEST_DATA
 
 
 class TestFinderUtils(TestCase):
-    def test_is_python_package(self):
+    def test_is_python_package(self) -> None:
         this_dir = Path(__file__).parent
         self.assertTrue(is_python_package(this_dir))
         self.assertFalse(is_python_package(TEST_DATA / "not_a_package"))
         self.assertFalse(is_python_package(TEST_DATA / "not_a_package" / "placeholder.txt"))
 
-    def test_is_python(self):
+    def test_is_python(self) -> None:
         self.assertFalse(is_python_module(TEST_DATA / "not_a_package" / "placeholder.txt"))
         self.assertTrue(is_python_module(Path(__file__)))
 
 
 class TestVirtualenvDetection(TestCase):
-    def test_is_a_venv(self):
+    def test_is_a_venv(self) -> None:
         path = TEST_DATA / "venvs" / "is_a_venv"
         self.assertTrue(is_virtualenv(path))
 
-    def test_not_a_venv(self):
+    def test_not_a_venv(self) -> None:
         path = TEST_DATA / "venvs" / "not_a_venv"
         self.assertFalse(is_virtualenv(path))
 
-    def test_long_path_not_a_venv(self):
+    def test_long_path_not_a_venv(self) -> None:
         """
         Windows doesn't allow extremely long paths. This unit test has to be
         run in Windows to be meaningful, though it shouldn't fail in other

--- a/tests/formatters/test_formatter_types.py
+++ b/tests/formatters/test_formatter_types.py
@@ -1,5 +1,6 @@
 import datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -8,13 +9,13 @@ from prospector.message import Location, Message
 from prospector.profiles.profile import ProspectorProfile
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[misc]
 def _simple_profile() -> ProspectorProfile:
     return ProspectorProfile(name="horse", profile_dict={}, inherit_order=["horse"])
 
 
-@pytest.fixture
-def _simple_summary() -> dict:
+@pytest.fixture  # type: ignore[misc]
+def _simple_summary() -> dict[str, Any]:
     return {
         "started": datetime.datetime(2014, 1, 1),
         "completed": datetime.datetime(2014, 1, 1),
@@ -27,17 +28,17 @@ def _simple_summary() -> dict:
     }
 
 
-def test_formatter_types(_simple_summary, _simple_profile):
-    for _formatter_name, formatter in FORMATTERS.items():
+def test_formatter_types(_simple_summary: Any, _simple_profile: Any) -> None:
+    for formatter in FORMATTERS.values():
         formatter_instance = formatter(_simple_summary, [], _simple_profile)
         assert isinstance(formatter_instance.render(True, True, False), str)
 
 
-def test_formatters_render(_simple_summary, _simple_profile):
+def test_formatters_render(_simple_summary: Any, _simple_profile: Any) -> None:
     """
     Basic test to ensure that formatters can at least render messages without erroring
     """
-    for _formatter_name, formatter in FORMATTERS.items():
+    for formatter in FORMATTERS.values():
         messages = [
             Message(
                 "testtool",

--- a/tests/is_python/test_is_python_module.py
+++ b/tests/is_python/test_is_python_module.py
@@ -5,7 +5,7 @@ import pytest
 from prospector.pathutils import is_python_module
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[misc]
     "filename,expected",
     [
         ("file.py", True),
@@ -19,6 +19,6 @@ from prospector.pathutils import is_python_module
         ("no_exec", False),
     ],
 )
-def test_is_python_module(filename: str, expected: bool):
+def test_is_python_module(filename: str, expected: bool) -> None:
     path = Path(__file__).parent / filename
     assert is_python_module(path) == expected

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from unittest import TestCase
 
@@ -10,23 +9,23 @@ BUILTIN_PROFILES = THIS_DIR / "../../prospector/profiles/profiles"
 
 
 class ProfileTestBase(TestCase):
-    def setUp(self):
-        self._profile_path = [str(THIS_DIR / "profiles"), str(BUILTIN_PROFILES)]
+    def setUp(self) -> None:
+        self._profile_path = [THIS_DIR / "profiles", BUILTIN_PROFILES]
 
 
 class TestOptionalProfiles(TestCase):
     def setUp(self) -> None:
-        self._profile_path = [str(THIS_DIR / "profiles/test_optional"), str(BUILTIN_PROFILES)]
+        self._profile_path = [THIS_DIR / "profiles/test_optional", BUILTIN_PROFILES]
 
-    def test_nonoptional_missing(self):
+    def test_nonoptional_missing(self) -> None:
         self.assertRaises(ProfileNotFound, ProspectorProfile.load, "nonoptional_missing", self._profile_path)
 
-    def test_optional_missing(self):
+    def test_optional_missing(self) -> None:
         # ensure loads without an exception to verify that a missing inherits works fine
         profile = ProspectorProfile.load("optional_missing", self._profile_path)
         self.assertTrue(profile.is_tool_enabled("dodgy"))
 
-    def test_optional_present(self):
+    def test_optional_present(self) -> None:
         # optional does not mean ignore so verify that values are inherited if present
         profile = ProspectorProfile.load("optional_present", self._profile_path)
         self.assertFalse(profile.is_tool_enabled("dodgy"))
@@ -35,24 +34,24 @@ class TestOptionalProfiles(TestCase):
 class TestToolRenaming(TestCase):
     def setUp(self) -> None:
         self._profile_path = [
-            str(THIS_DIR / "profiles/renaming_pepX/test_inheritance"),
-            str(THIS_DIR / "profiles/renaming_pepX"),
-            str(BUILTIN_PROFILES),
+            THIS_DIR / "profiles/renaming_pepX/test_inheritance",
+            THIS_DIR / "profiles/renaming_pepX",
+            BUILTIN_PROFILES,
         ]
 
-    def test_old_inherits_from_new(self):
+    def test_old_inherits_from_new(self) -> None:
         profile = ProspectorProfile.load("child_oldname.yaml", self._profile_path, allow_shorthand=False)
 
         assert profile.is_tool_enabled("pydocstyle")
         assert profile.is_tool_enabled("pycodestyle")
-        assert "D401" in profile.pydocstyle["enable"]
-        assert "D401" not in profile.pydocstyle["disable"]
+        assert "D401" in profile.pydocstyle["enable"]  # type: ignore[attr-defined]
+        assert "D401" not in profile.pydocstyle["disable"]  # type: ignore[attr-defined]
 
-        assert "E266" not in profile.pycodestyle["disable"]
+        assert "E266" not in profile.pycodestyle["disable"]  # type: ignore[attr-defined]
 
-        assert profile.pycodestyle["options"]["max-line-length"] == 120
+        assert profile.pycodestyle["options"]["max-line-length"] == 120  # type: ignore[attr-defined]
 
-    def test_new_inherits_from_old(self):
+    def test_new_inherits_from_old(self) -> None:
         """
         Ensure that `pep8` can inherit from a `pycodecstyle` block and vice versa
         """
@@ -60,14 +59,14 @@ class TestToolRenaming(TestCase):
 
         assert profile.is_tool_enabled("pydocstyle")
         assert profile.is_tool_enabled("pycodestyle")
-        assert "D401" not in profile.pydocstyle["disable"]
-        assert "D401" in profile.pydocstyle["enable"]
+        assert "D401" not in profile.pydocstyle["disable"]  # type: ignore[attr-defined]
+        assert "D401" in profile.pydocstyle["enable"]  # type: ignore[attr-defined]
 
-        assert "E266" not in profile.pycodestyle["disable"]
+        assert "E266" not in profile.pycodestyle["disable"]  # type: ignore[attr-defined]
 
-        assert profile.pycodestyle["options"]["max-line-length"] == 140
+        assert profile.pycodestyle["options"]["max-line-length"] == 140  # type: ignore[attr-defined]
 
-    def test_legacy_names_equivalent(self):
+    def test_legacy_names_equivalent(self) -> None:
         """
         'pep8' tool was renamed to pycodestyle, 'pep257' tool was renamed to pydocstyle
 
@@ -89,9 +88,9 @@ class TestToolRenaming(TestCase):
         for prof in (profile_old, profile_new):
             self.assertTrue(prof.is_tool_enabled("pycodestyle"))
             self.assertTrue(prof.is_tool_enabled("pydocstyle"))
-            self.assertEqual(prof.pycodestyle["options"]["max-line-length"], 120)
+            self.assertEqual(prof.pycodestyle["options"]["max-line-length"], 120)  # type: ignore[attr-defined]
 
-    def test_pep8_shorthand_with_newname(self):
+    def test_pep8_shorthand_with_newname(self) -> None:
         """
         'pep8' is still a valid entry in the profile but in the future, only as a shorthand ("pep8: full")
         however for now, it also has to be able to configure pycodestyle
@@ -99,66 +98,66 @@ class TestToolRenaming(TestCase):
         profile = ProspectorProfile.load("pep8_shorthand_pycodestyle", self._profile_path, allow_shorthand=True)
         self.assertTrue("full_pep8" in profile.inherit_order)
         self.assertTrue(profile.is_tool_enabled("pycodestyle"))
-        self.assertEqual(profile.pycodestyle["options"]["max-line-length"], 120)
+        self.assertEqual(profile.pycodestyle["options"]["max-line-length"], 120)  # type: ignore[attr-defined]
 
 
 class TestProfileParsing(ProfileTestBase):
-    def test_empty_disable_list(self):
+    def test_empty_disable_list(self) -> None:
         """
         This test verifies that a profile can still be loaded if it contains
         an empty 'pylint.disable' list
         """
         profile = ProspectorProfile.load("empty_disable_list", self._profile_path, allow_shorthand=False)
-        self.assertEqual([], profile.pylint["disable"])
+        self.assertEqual([], profile.pylint["disable"])  # type: ignore[attr-defined]
 
-    def test_empty_profile(self):
+    def test_empty_profile(self) -> None:
         """
         Verifies that a completely empty profile can still be parsed and have
         default values
         """
         profile = ProspectorProfile.load("empty_profile", self._profile_path, allow_shorthand=False)
-        self.assertEqual([], profile.pylint["disable"])
+        self.assertEqual([], profile.pylint["disable"])  # type: ignore[attr-defined]
 
-    def test_ignores(self):
+    def test_ignores(self) -> None:
         profile = ProspectorProfile.load("ignores", self._profile_path)
         self.assertEqual(["^tests/", "/migrations/"].sort(), profile.ignore_patterns.sort())
 
-    def test_enabled_in_disabled(self):
+    def test_enabled_in_disabled(self) -> None:
         """
         If a
         :return:
         """
 
-    def test_disable_tool(self):
+    def test_disable_tool(self) -> None:
         profile = ProspectorProfile.load("pylint_disabled", self._profile_path)
         self.assertFalse(profile.is_tool_enabled("pylint"))
         self.assertTrue(profile.is_tool_enabled("pycodestyle"))
 
-    def test_load_plugins(self):
+    def test_load_plugins(self) -> None:
         profile = ProspectorProfile.load("pylint_load_plugins", self._profile_path)
-        self.assertEqual(["first_plugin", "second_plugin"], profile.pylint["load-plugins"])
+        self.assertEqual(["first_plugin", "second_plugin"], profile.pylint["load-plugins"])  # type: ignore[attr-defined]
 
 
 class TestProfileInheritance(ProfileTestBase):
-    def _example_path(self, testname):
-        return os.path.join(os.path.dirname(__file__), "profiles", "inheritance", testname)
+    def _example_path(self, testname: str) -> Path:
+        return Path(__file__).parent / "profiles" / "inheritance" / testname
 
-    def _load(self, testname):
+    def _load(self, testname: str) -> ProspectorProfile:
         profile_path = self._profile_path + [self._example_path(testname)]
         return ProspectorProfile.load("start", profile_path)
 
-    def test_simple_inheritance(self):
+    def test_simple_inheritance(self) -> None:
         profile = ProspectorProfile.load("inherittest3", self._profile_path, allow_shorthand=False)
-        disable = profile.pylint["disable"]
+        disable = profile.pylint["disable"]  # type: ignore[attr-defined]
         disable.sort()
         self.assertEqual(["I0002", "I0003", "raw-checker-failed"], disable)
 
-    def test_disable_tool_inheritance(self):
+    def test_disable_tool_inheritance(self) -> None:
         profile = ProspectorProfile.load("pydocstyle_and_pylint_disabled", self._profile_path)
         self.assertFalse(profile.is_tool_enabled("pylint"))
         self.assertFalse(profile.is_tool_enabled("pydocstyle"))
 
-    def test_precedence(self):
+    def test_precedence(self) -> None:
         profile = self._load("precedence")
         self.assertTrue(profile.is_tool_enabled("pylint"))
         self.assertTrue("expression-not-assigned" in profile.get_disabled_messages("pylint"))
@@ -168,15 +167,15 @@ class TestProfileInheritance(ProfileTestBase):
 
     #        self.assertFalse("D401" in profile.get_disabled_messages("pydocstyle"))
 
-    def test_strictness_equivalence(self):
+    def test_strictness_equivalence(self) -> None:
         profile = self._load("strictness_equivalence")
         medium_strictness = ProspectorProfile.load("strictness_medium", self._profile_path)
         self.assertListEqual(
-            sorted(profile.pylint["disable"]),
-            sorted(medium_strictness.pylint["disable"]),
+            sorted(profile.pylint["disable"]),  # type: ignore[attr-defined]
+            sorted(medium_strictness.pylint["disable"]),  # type: ignore[attr-defined]
         )
 
-    def test_shorthand_inheritance(self):
+    def test_shorthand_inheritance(self) -> None:
         profile = self._load("shorthand_inheritance")
         high_strictness = ProspectorProfile.load(
             "strictness_high",
@@ -186,23 +185,23 @@ class TestProfileInheritance(ProfileTestBase):
             # but do include the profiles that the start.yaml will
             forced_inherits=["doc_warnings", "no_member_warnings"],
         )
-        self.assertDictEqual(profile.pylint, high_strictness.pylint)
-        self.assertDictEqual(profile.pycodestyle, high_strictness.pycodestyle)
-        self.assertDictEqual(profile.pyflakes, high_strictness.pyflakes)
+        self.assertDictEqual(profile.pylint, high_strictness.pylint)  # type: ignore[attr-defined]
+        self.assertDictEqual(profile.pycodestyle, high_strictness.pycodestyle)  # type: ignore[attr-defined]
+        self.assertDictEqual(profile.pyflakes, high_strictness.pyflakes)  # type: ignore[attr-defined]
 
-    def test_tool_enabled(self):
+    def test_tool_enabled(self) -> None:
         profile = self._load("tool_enabled")
         self.assertTrue(profile.is_tool_enabled("pydocstyle"))
         self.assertFalse(profile.is_tool_enabled("pylint"))
 
-    def test_pycodestyle_inheritance(self):
+    def test_pycodestyle_inheritance(self) -> None:
         profile = self._load("pep8")
         self.assertTrue("full_pep8" in profile.inherit_order)
 
-    def test_module_inheritance(self):
+    def test_module_inheritance(self) -> None:
         profile = ProspectorProfile.load("inherittest-module", self._profile_path, allow_shorthand=False)
-        self.assertEqual(["test-from-module"], profile.pylint["disable"])
+        self.assertEqual(["test-from-module"], profile.pylint["disable"])  # type: ignore[attr-defined]
 
-    def test_module_file_inheritance(self):
+    def test_module_file_inheritance(self) -> None:
         profile = ProspectorProfile.load("inherittest-module-file", self._profile_path, allow_shorthand=False)
-        self.assertEqual(["alternate-test-from-module"], profile.pylint["disable"])
+        self.assertEqual(["alternate-test-from-module"], profile.pylint["disable"])  # type: ignore[attr-defined]

--- a/tests/suppression/test_blender_suppression.py
+++ b/tests/suppression/test_blender_suppression.py
@@ -2,15 +2,16 @@ import unittest
 from pathlib import Path
 
 from prospector.suppression import Ignore, get_suppressions
+from prospector.tools.base import ToolBase
 from prospector.tools.mypy import MypyTool
 from prospector.tools.pylint import PylintTool
 from prospector.tools.ruff import RuffTool
 
 
 class BlenderSuppressionsTest(unittest.TestCase):
-    def test_blender_suppressions_pylint(self):
+    def test_blender_suppressions_pylint(self) -> None:
         path = Path(__file__).parent / "testdata" / "test_blender_suppressions" / "test.py"
-        tools = {"pylint": PylintTool()}
+        tools: dict[str, ToolBase] = {"pylint": PylintTool()}
         blend_combos = [[("pylint", "n2"), ("other", "o2")]]
 
         _, _, messages_to_ignore = get_suppressions([path], [], tools, blending=False, blend_combos=blend_combos)
@@ -21,9 +22,9 @@ class BlenderSuppressionsTest(unittest.TestCase):
         assert 2 in messages_to_ignore[path]
         assert messages_to_ignore[path][2] == {Ignore("pylint", "n2"), Ignore("other", "o2")}
 
-    def test_blender_suppressions_mypy(self):
+    def test_blender_suppressions_mypy(self) -> None:
         path = Path(__file__).parent / "testdata" / "test_blender_suppressions" / "test.py"
-        tools = {"mypy": MypyTool()}
+        tools: dict[str, ToolBase] = {"mypy": MypyTool()}
         blend_combos = [[("mypy", "n3"), ("other", "o3")]]
 
         _, _, messages_to_ignore = get_suppressions([path], [], tools, blending=False, blend_combos=blend_combos)
@@ -34,9 +35,9 @@ class BlenderSuppressionsTest(unittest.TestCase):
         assert 3 in messages_to_ignore[path]
         assert messages_to_ignore[path][3] == {Ignore("mypy", "n3"), Ignore("other", "o3")}
 
-    def test_blender_suppressions_ruff(self):
+    def test_blender_suppressions_ruff(self) -> None:
         path = Path(__file__).parent / "testdata" / "test_blender_suppressions" / "test.py"
-        tools = {"ruff": RuffTool()}
+        tools: dict[str, ToolBase] = {"ruff": RuffTool()}
         blend_combos = [[("ruff", "n1"), ("other", "o1")]]
 
         _, _, messages_to_ignore = get_suppressions([path], [], tools, blending=False, blend_combos=blend_combos)

--- a/tests/suppression/test_suppression.py
+++ b/tests/suppression/test_suppression.py
@@ -7,17 +7,17 @@ from tests.utils import patch_workdir_argv
 
 
 class SuppressionTest(unittest.TestCase):
-    def _get_file_contents(self, name):
+    def _get_file_contents(self, name: str) -> list[str]:
         path = os.path.join(os.path.dirname(__file__), "testdata", name)
         with open(path) as testfile:
             return testfile.readlines()
 
-    def test_ignore_file(self):
+    def test_ignore_file(self) -> None:
         file_contents = self._get_file_contents("test_ignore_file/test.py")
         whole_file, _, _ = get_noqa_suppressions(file_contents)
         self.assertTrue(whole_file)
 
-    def test_ignore_lines(self):
+    def test_ignore_lines(self) -> None:
         file_contents = self._get_file_contents("test_ignore_lines/test.py")
         _, lines, messages_to_ignore = get_noqa_suppressions(file_contents)
         self.assertSetEqual({1, 2, 3, 4}, lines)
@@ -37,21 +37,23 @@ class SuppressionTest(unittest.TestCase):
         assert l8a.source is None
         assert l8a.code == "code1"
 
-    def test_ignore_enum_error(self):
+    def test_ignore_enum_error(self) -> None:
         file_contents = self._get_file_contents("test_ignore_enum/test.py")
         _, lines, _ = get_noqa_suppressions(file_contents)
         self.assertSetEqual({5}, lines)
 
-    def test_filter_messages(self):
+    def test_filter_messages(self) -> None:
         with patch_workdir_argv(
             target="setoptconf.source.commandline.sys.argv",
             workdir=Path(__file__).parent / "testdata/test_filter_messages",
         ) as pros:
+            assert pros.summary is not None
             self.assertEqual(0, pros.summary["message_count"])
 
-    def test_filter_messages_negative(self):
+    def test_filter_messages_negative(self) -> None:
         with patch_workdir_argv(
             target="setoptconf.source.commandline.sys.argv",
             workdir=Path(__file__).parent / "testdata/test_filter_messages_negative",
         ) as pros:
+            assert pros.summary is not None
             self.assertEqual(5, pros.summary["message_count"])

--- a/tests/test_blender.py
+++ b/tests/test_blender.py
@@ -5,25 +5,25 @@ from prospector.message import Location, Message
 
 
 class TestBlendLine(TestCase):
-    BLEND = (
-        (("s1", "s1c01"), ("s2", "s2c12")),
-        (("s3", "s3c81"), ("s1", "s1c04"), ("s2", "s2c44")),
-    )
+    BLEND = [
+        [("s1", "s1c01"), ("s2", "s2c12")],
+        [("s3", "s3c81"), ("s1", "s1c04"), ("s2", "s2c44")],
+    ]
 
-    def _do_test(self, messages, expected):
-        def _msg(source, code):
+    def _do_test(self, messages: tuple[tuple[str, str], ...], expected: tuple[tuple[str, str], ...]) -> None:
+        def _msg(source: str, code: str) -> Message:
             loc = Location("path.py", "path", None, 1, 0)
             return Message(source, code, loc, "Test Message")
 
-        messages = [_msg(*m) for m in messages]
-        expected = set(expected)
+        messages_list = [_msg(*m) for m in messages]
+        expected_set = set(expected)
 
-        blended = blender.blend_line(messages, TestBlendLine.BLEND)
+        blended = blender.blend_line(messages_list, TestBlendLine.BLEND)
         result = {(msg.source, msg.code) for msg in blended}
 
-        self.assertEqual(expected, result)
+        self.assertEqual(expected_set, result)
 
-    def test_blend_line(self):
+    def test_blend_line(self) -> None:
         messages = (("s2", "s2c12"), ("s2", "s2c11"), ("s1", "s1c01"))
 
         expected = (
@@ -32,7 +32,7 @@ class TestBlendLine(TestCase):
         )
         self._do_test(messages, expected)
 
-    def test_single_blend(self):
+    def test_single_blend(self) -> None:
         # these three should be blended together
         messages = (
             ("s1", "s1c04"),
@@ -43,22 +43,22 @@ class TestBlendLine(TestCase):
         expected = (("s3", "s3c81"),)
         self._do_test(messages, expected)
 
-    def test_nothing_to_blend(self):
+    def test_nothing_to_blend(self) -> None:
         """
         Verifies that messages pass through if there is nothing to blend
         """
         messages = (("s4", "s4c99"), ("s4", "s4c01"), ("s5", "s5c51"), ("s6", "s6c66"))
         self._do_test(messages, messages)  # expected = messages
 
-    def test_no_messages(self):
+    def test_no_messages(self) -> None:
         """
         Ensures that the blending works fine when there are no messages to blend
         """
         self._do_test((), ())
 
 
-def test_multiple_lines():
-    def _msg(source, code, line_number):
+def test_multiple_lines() -> None:
+    def _msg(source: str, code: str, line_number: int) -> Message:
         loc = Location("path.py", "path", None, line_number, 0)
         return Message(source, code, loc, "Test Message")
 
@@ -69,10 +69,10 @@ def test_multiple_lines():
         _msg("s1", "s1c001", 6),
     ]
 
-    result = blender.blend(messages, ((("s1", "s1c001"), ("s2", "s2c101")),))
-    result = [(msg.source, msg.code, msg.location.line) for msg in result]
-    result = set(result)
+    result = blender.blend(messages, [[("s1", "s1c001"), ("s2", "s2c101")]])
+    result_tuple = [(msg.source, msg.code, msg.location.line) for msg in result]
+    result_set = set(result_tuple)
 
     expected = {("s1", "s1c001", 4), ("s1", "s1c001", 6), ("s2", "s2c001", 6)}
 
-    assert expected == result
+    assert expected == result_set

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -5,7 +5,7 @@ from prospector.message import Location
 
 
 class LocationPathTest(TestCase):
-    def test_paths(self):
+    def test_paths(self) -> None:
         """
         Tests the absolute and relative path conversion
         """
@@ -15,72 +15,73 @@ class LocationPathTest(TestCase):
         absolute = root / "tests/test_message.py"
         self.assertEqual(loc.absolute_path(), absolute)
 
-    def test_strings_or_paths(self):
+    def test_strings_or_paths(self) -> None:
         """
         For ease of use the Location object can accept a path as a Path or a string
         """
-        path = "/tmp/path/module1.py"
-        args = ["module1", "somefunc", 12, 2]
-        self.assertEqual(Location("/tmp/path/module1.py", *args), Location(Path(path), *args))
+        self.assertEqual(
+            Location("/tmp/path/module1.py", "module1", "somefunc", 12, 2),  # nosec
+            Location(Path("/tmp/path/module1.py"), "module1", "somefunc", 12, 2),  # nosec
+        )
 
-    def test_bad_path_input(self):
+    def test_bad_path_input(self) -> None:
         self.assertRaises(ValueError, Location, 3.2, "module", "func", 1, 2)
 
 
 class LocationOrderTest(TestCase):
-    def test_path_order(self):
+    def test_path_order(self) -> None:
         locs = [
-            Location(Path("/tmp/path/module3.py"), "module3", "somefunc", 15, 0),
-            Location(Path("/tmp/path/module1.py"), "module1", "somefunc", 10, 0),
-            Location("/tmp/path/module2.py", "module2", "somefunc", 9, 0),
+            Location(Path("/tmp/path/module3.py"), "module3", "somefunc", 15, 0),  # nosec
+            Location(Path("/tmp/path/module1.py"), "module1", "somefunc", 10, 0),  # nosec
+            Location("/tmp/path/module2.py", "module2", "somefunc", 9, 0),  # nosec
         ]
 
-        paths = [loc.path for loc in locs]
+        paths = [loc.path for loc in locs if loc.path is not None]
         expected = sorted(paths)
 
         self.assertEqual(expected, [loc.path for loc in sorted(locs)])
 
-    def test_line_order(self):
+    def test_line_order(self) -> None:
         locs = [
-            Location("/tmp/path/module1.py", "module1", "somefunc", 15, 0),
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 0),
-            Location("/tmp/path/module1.py", "module1", "somefunc", 12, 0),
+            Location("/tmp/path/module1.py", "module1", "somefunc", 15, 0),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 0),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", 12, 0),  # nosec
         ]
 
-        lines = [loc.line for loc in locs]
+        lines = [loc.line for loc in locs if loc.line is not None]
         expected = sorted(lines)
 
         self.assertEqual(expected, [loc.line for loc in sorted(locs)])
 
-    def test_sort_between_none_lines(self):
+    def test_sort_between_none_lines(self) -> None:
         locs = [
-            Location("/tmp/path/module1.py", "module1", "somefunc", 15, 0),
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 0),
-            Location("/tmp/path/module1.py", "module1", "somefunc", -1, 0),
+            Location("/tmp/path/module1.py", "module1", "somefunc", 15, 0),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 0),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", -1, 0),  # nosec
         ]
 
         lines = [(loc.line or -1) for loc in locs]
-        expected = [None if l == -1 else l for l in sorted(lines)]
+        expected = [None if line == -1 else line for line in sorted(lines)]
 
         self.assertEqual(expected, [loc.line for loc in sorted(locs)])
 
-    def test_char_order(self):
+    def test_char_order(self) -> None:
         locs = [
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 7),
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 0),
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 2),
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 7),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 0),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 2),  # nosec
         ]
 
-        chars = [loc.character for loc in locs]
+        chars = [loc.character for loc in locs if loc.character is not None]
         expected = sorted(chars)
 
         self.assertEqual(expected, [loc.character for loc in sorted(locs)])
 
-    def test_sort_between_none_chars(self):
+    def test_sort_between_none_chars(self) -> None:
         locs = [
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, -1),
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 1),
-            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 2),
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, -1),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 1),  # nosec
+            Location("/tmp/path/module1.py", "module1", "somefunc", 10, 2),  # nosec
         ]
 
         chars = [(loc.character or -1) for loc in locs]

--- a/tests/tools/bandit/test_bandit_tool.py
+++ b/tests/tools/bandit/test_bandit_tool.py
@@ -8,12 +8,12 @@ from prospector.tools.bandit import BanditTool
 
 
 class TestBanditTool(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         with patch("sys.argv", [""]):
             self.config = ProspectorConfig()
         self.bandit_tool = BanditTool()
 
-    def test_hardcoded_password_string(self):
+    def test_hardcoded_password_string(self) -> None:
         found_files = FileFinder(Path(__file__).parent / "testpath/testfile.py")
         self.bandit_tool.configure(self.config, found_files)
         messages = self.bandit_tool.run(found_files)

--- a/tests/tools/mypy/test_mypy_tool.py
+++ b/tests/tools/mypy/test_mypy_tool.py
@@ -10,7 +10,7 @@ from prospector.tools.exceptions import BadToolConfig
 try:
     from prospector.tools.mypy import MypyTool, format_message
 except ImportError:
-    raise SkipTest  # noqa: B904
+    raise SkipTest  # type: ignore[call-arg] # noqa: B904
 
 
 class TestMypyTool(TestCase):
@@ -20,15 +20,15 @@ class TestMypyTool(TestCase):
         with patch("sys.argv", ["prospector", "--profile", str(profile_path.absolute())]):
             return ProspectorConfig()
 
-    def test_unrecognised_options(self):
+    def test_unrecognised_options(self) -> None:
         finder = FileFinder(Path(__file__).parent)
         self.assertRaises(BadToolConfig, self._get_config("mypy_bad_options").get_tools, finder)
 
-    def test_good_options(self):
+    def test_good_options(self) -> None:
         finder = FileFinder(Path(__file__).parent)
         self._get_config("mypy_good_options").get_tools(finder)
 
-    def test_ignore_code(self):
+    def test_ignore_code(self) -> None:
         mypy_tool = MypyTool()
         assert mypy_tool.get_ignored_codes("toto # type: ignore[misc]") == [("misc", 0)]
         assert mypy_tool.get_ignored_codes("toto # type: ignore[misc] # toto") == [("misc", 0)]
@@ -38,22 +38,22 @@ class TestMypyTool(TestCase):
 
 
 class TestMypyMessageFormat(TestCase):
-    def test_format_message_with_character(self):
+    def test_format_message_with_character(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=17, character=2)
         expected = Message(source="mypy", code="error", location=location, message="Important error")
         self.assertEqual(format_message("file.py:17:2: error: Important error"), expected)
 
-    def test_format_message_without_character_and_columns_in_message(self):
+    def test_format_message_without_character_and_columns_in_message(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=17, character=None)
         expected = Message(source="mypy", code="note", location=location, message="Important error")
         self.assertEqual(format_message('file.py:17: note: unused "type: ignore" comment'), expected)
 
-    def test_format_message_without_character(self):
+    def test_format_message_without_character(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=17, character=None)
         expected = Message(source="mypy", code="error", location=location, message="Important error")
         self.assertEqual(format_message("file.py:17: error: Important error"), expected)
 
-    def test_format_dupplicated_module_win(self):
+    def test_format_dupplicated_module_win(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=0, character=None)
         expected = Message(
             source="mypy",
@@ -66,7 +66,7 @@ class TestMypyMessageFormat(TestCase):
             expected,
         )
 
-    def test_format_dupplicated_module_linux(self):
+    def test_format_dupplicated_module_linux(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=0, character=None)
         expected = Message(
             source="mypy",

--- a/tests/tools/pycodestyle/test_pycodestyle_tool.py
+++ b/tests/tools/pycodestyle/test_pycodestyle_tool.py
@@ -1,33 +1,41 @@
 import os
+from collections.abc import Iterable
 from pathlib import Path
+from typing import Any, Optional
 from unittest import TestCase
 
 from prospector.config import ProspectorConfig
 from prospector.finder import FileFinder
+from prospector.message import Message
 from prospector.tools.pycodestyle import PycodestyleTool
 
 from ...utils import patch_execution
 
 
 class TestPycodestyleTool(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self._tool = PycodestyleTool()
 
-    def _configure(self, filename, *cli_args, workdir=None):
+    def _configure(
+        self, filename: str, *cli_args: Any, workdir: Optional[Path] = None
+    ) -> tuple[Optional[str], Optional[Iterable[Message]]]:
         with patch_execution(*cli_args, set_cwd=workdir):
             found_files = FileFinder(Path(__file__).parent / filename)
             config = ProspectorConfig(workdir)
-            return self._tool.configure(config, found_files)
+            result = self._tool.configure(config, found_files)
+            assert result is not None
+            return result
 
-    def test_absolute_path_is_computed_correctly(self):
+    def test_absolute_path_is_computed_correctly(self) -> None:
         root = os.path.join(os.path.dirname(__file__), "testpath", "testfile.py")
         root_sep_split = root.split(os.path.sep)
         root_os_split = os.path.split(root)
         self._configure("testpath/testfile.py")
+        assert self._tool.checker is not None
         self.assertNotEqual(self._tool.checker.paths, [os.path.join(*root_sep_split)])
         self.assertEqual(self._tool.checker.paths, [os.path.join(*root_os_split)])
 
-    def test_pycodestyle_space_and_tabs(self):
+    def test_pycodestyle_space_and_tabs(self) -> None:
         workdir = Path(__file__).parent / "testpath"
         self._configure("testpath/test_space_tab.py", "--full-pep8", workdir=workdir)
         messages = self._tool.run([])
@@ -35,13 +43,13 @@ class TestPycodestyleTool(TestCase):
         self.assertTrue({"E101", "E111", "W191"} <= {m.code for m in messages})
 
     # TODO: legacy config handling here:
-    def test_find_pep8_section_in_config(self):
+    def test_find_pep8_section_in_config(self) -> None:
         workdir = Path(__file__).parent / "testsettings/pep8"
         configured_by, _ = self._configure("testsettings/pep8/testfile.py", workdir=workdir)
         expected_config_path = str(workdir / "setup.cfg")
         self.assertEqual(configured_by, f"Configuration found at {expected_config_path}")
 
-    def test_find_pycodestyle_section_in_config(self):
+    def test_find_pycodestyle_section_in_config(self) -> None:
         workdir = Path(__file__).parent / "testsettings/pycodestyle"
         configured_by, _ = self._configure("testsettings/pycodestyle/testfile.py", workdir=workdir)
         expected_config_path = str(workdir / "setup.cfg")

--- a/tests/tools/pylint/parallel/one.py
+++ b/tests/tools/pylint/parallel/one.py
@@ -1,2 +1,2 @@
-def this_is_a_line_that_is_longer_than_40_characters():
+def this_is_a_line_that_is_longer_than_40_characters() -> str:
     return "hi"

--- a/tests/tools/pylint/test_pylint_tool.py
+++ b/tests/tools/pylint/test_pylint_tool.py
@@ -1,17 +1,21 @@
 import os
+from collections.abc import Iterable
 from pathlib import Path, PosixPath
-from typing import Tuple
+from typing import Callable, Optional, Tuple, Union
 from unittest import TestCase
 from unittest.mock import patch
 
 from prospector.config import ProspectorConfig
 from prospector.finder import FileFinder
+from prospector.message import Message
 from prospector.tools.pylint import PylintTool
 
 THIS_DIR = Path(__file__).parent
 
 
-def _get_pylint_tool_and_prospector_config(argv_patch=None) -> Tuple[PylintTool, ProspectorConfig]:
+def _get_pylint_tool_and_prospector_config(
+    argv_patch: Optional[list[str]] = None,
+) -> Tuple[PylintTool, ProspectorConfig]:
     if argv_patch is None:
         argv_patch = [""]
     with patch("sys.argv", argv_patch):
@@ -20,13 +24,15 @@ def _get_pylint_tool_and_prospector_config(argv_patch=None) -> Tuple[PylintTool,
     return pylint_tool, config
 
 
-def _get_test_files(*names: str, exclusion_filters=None):
+def _get_test_files(
+    *names: Union[str, Path], exclusion_filters: Optional[Iterable[Callable[[Path], bool]]] = None
+) -> FileFinder:
     paths = [THIS_DIR / name for name in names]
     return FileFinder(*paths, exclusion_filters=exclusion_filters)
 
 
 class TestPylintTool(TestCase):
-    def test_checkpath_includes_no_init_modules(self):
+    def test_checkpath_includes_no_init_modules(self) -> None:
         """
         If a subdirectory of a package has a .py file but no __init__.py it should still be included
         """
@@ -36,7 +42,7 @@ class TestPylintTool(TestCase):
         assert len(check_paths) == 2
         assert sorted(Path(p).name for p in check_paths) == ["file3.py", "test_no_init_found"]
 
-    def test_no_duplicates_in_checkpath(self):
+    def test_no_duplicates_in_checkpath(self) -> None:
         """
         This checks that the pylint tool will not generate a list of packages and subpackages -
         if there is a hierarchy there is no need to duplicate sub-packages in the list to be checked
@@ -48,10 +54,10 @@ class TestPylintTool(TestCase):
         assert len(check_paths) == 1
         assert [str(Path(p).relative_to(root)) for p in check_paths] == ["pkg1"]
 
-    def test_pylint_config(self):
+    def test_pylint_config(self) -> None:
         """Verifies that prospector will configure pylint with any pylint-specific configuration if found"""
 
-        def _has_message(msg_list, code):
+        def _has_message(msg_list: list[Message], code: str) -> bool:
             return any([message.code == code and message.source == "pylint" for message in msg_list])
 
         for config_type in ("pylintrc", "pylintrc2", "pyproject", "setup.cfg"):
@@ -67,7 +73,7 @@ class TestPylintTool(TestCase):
             messages = pylint_tool.run(found_files)
             self.assertTrue(_has_message(messages, "line-too-long"), msg=config_type)
 
-    def test_absolute_path_is_computed_correctly(self):
+    def test_absolute_path_is_computed_correctly(self) -> None:
         pylint_tool, config = _get_pylint_tool_and_prospector_config()
         root = os.path.join(os.path.dirname(__file__), "testpath", "testfile.py")
         root_sep_split = root.split(os.path.sep)
@@ -77,7 +83,7 @@ class TestPylintTool(TestCase):
         self.assertNotEqual(pylint_tool._args, [os.path.join(*root_sep_split)])
         self.assertEqual(pylint_tool._args, [PosixPath(os.path.join(*root_os_split))])
 
-    def test_wont_throw_false_positive_relative_beyond_top_level(self):
+    def test_wont_throw_false_positive_relative_beyond_top_level(self) -> None:
         with patch("os.getcwd", return_value=os.path.realpath("tests/tools/pylint/testpath/")):
             pylint_tool, config = _get_pylint_tool_and_prospector_config()
         found_files = _get_test_files("testpath/src/mcve/foobar.py")
@@ -85,20 +91,21 @@ class TestPylintTool(TestCase):
         messages = pylint_tool.run(found_files)
         self.assertListEqual(messages, [])
 
-    def test_will_throw_useless_suppression(self):
+    def test_will_throw_useless_suppression(self) -> None:
         with patch("os.getcwd", return_value=os.path.realpath("tests/tools/pylint/testpath/")):
             pylint_tool, config = _get_pylint_tool_and_prospector_config(argv_patch=["", "-t", "pylint"])
 
         found_files = _get_test_files("testpath", "testpath/test_useless_suppression.py")
         pylint_tool.configure(config, found_files)
         # useless-suppression is now disable by default in pylint
+        assert pylint_tool._linter is not None
         pylint_tool._linter.enable("useless-suppression")
         messages = pylint_tool.run(found_files)
         assert any(m.code == "useless-suppression" for m in messages), (
             "There should be at least one useless suppression"
         )
 
-    def test_parallel_execution(self):
+    def test_parallel_execution(self) -> None:
         root = THIS_DIR / "parallel"
 
         with patch("pathlib.Path.cwd", return_value=root.absolute()):
@@ -107,12 +114,13 @@ class TestPylintTool(TestCase):
 
         found_files = _get_test_files(root, exclusion_filters=[config.make_exclusion_filter()])
         pylint_tool.configure(config, found_files)
+        assert pylint_tool._linter is not None
         assert pylint_tool._linter.config.jobs == 2
 
         messages = pylint_tool.run(found_files)
         assert "line-too-long" in [msg.code for msg in messages if msg.source == "pylint"]
 
-    def test_ignore_code(self):
+    def test_ignore_code(self) -> None:
         pylint_tool, _ = _get_pylint_tool_and_prospector_config()
         assert pylint_tool.get_ignored_codes("toto # pylint: disable=missing-docstring") == [("missing-docstring", 0)]
         assert pylint_tool.get_ignored_codes("toto # pylint: disable=missing-docstring # titi") == [

--- a/tests/tools/pyright/test_pyright_tool.py
+++ b/tests/tools/pyright/test_pyright_tool.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 from unittest import SkipTest, TestCase
 from unittest.mock import patch
 
@@ -11,7 +12,7 @@ from prospector.tools.exceptions import BadToolConfig
 try:
     from prospector.tools.pyright import format_messages
 except ImportError:
-    raise SkipTest  # noqa: B904
+    raise SkipTest  # type: ignore[call-arg] # noqa: B904
 
 
 class TestPyrightTool(TestCase):
@@ -21,20 +22,20 @@ class TestPyrightTool(TestCase):
         with patch("sys.argv", ["prospector", "--profile", str(profile_path.absolute())]):
             return ProspectorConfig()
 
-    def test_unrecognised_options(self):
+    def test_unrecognised_options(self) -> None:
         finder = FileFinder(Path(__file__).parent)
         self.assertRaises(BadToolConfig, self._get_config("pyright_bad_options").get_tools, finder)
 
-    def test_good_options(self):
+    def test_good_options(self) -> None:
         finder = FileFinder(Path(__file__).parent)
         self._get_config("pyright_good_options").get_tools(finder)
 
 
 class TestPyrightMessageFormat(TestCase):
-    def _encode_messages(self, messages):
+    def _encode_messages(self, messages: list[dict[str, Any]]) -> str:
         return json.dumps({"generalDiagnostics": messages})
 
-    def test_format_message_with_character(self):
+    def test_format_message_with_character(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=17, character=2)
         expected = Message(source="pyright", code="error", location=location, message="Important error")
         self.assertEqual(
@@ -53,7 +54,7 @@ class TestPyrightMessageFormat(TestCase):
             [expected],
         )
 
-    def test_format_message_without_character(self):
+    def test_format_message_without_character(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=17, character=-1)
         expected = Message(source="pyright", code="note", location=location, message="Important error")
         self.assertEqual(
@@ -72,7 +73,7 @@ class TestPyrightMessageFormat(TestCase):
             [expected],
         )
 
-    def test_format_message_without_line(self):
+    def test_format_message_without_line(self) -> None:
         location = Location(path="file.py", module=None, function=None, line=-1, character=-1)
         expected = Message(
             source="pyright",

--- a/tests/tools/pyroma/test_pyroma_tool.py
+++ b/tests/tools/pyroma/test_pyroma_tool.py
@@ -7,7 +7,7 @@ from prospector.tools.pyroma import PyromaTool
 from ...utils import patch_cli, patch_cwd
 
 
-def test_forced_include():
+def test_forced_include() -> None:
     """
     The built-in default profiles for prospector will ignore `setup.py` by default, but this needs
     to be explicitly overridden for pyroma *only*

--- a/tests/tools/utils.py
+++ b/tests/tools/utils.py
@@ -5,5 +5,5 @@ from prospector.finder import FileFinder
 
 
 class TestCaseWithFiles(TestCase):
-    def get_test_files(self, name, workdir=None):
-        return FileFinder(Path(__file__).parent / name, workdir=workdir)
+    def get_test_files(self, name: str) -> FileFinder:
+        return FileFinder(Path(__file__).parent / name)

--- a/tests/tools/vulture/test_vulture_tool.py
+++ b/tests/tools/vulture/test_vulture_tool.py
@@ -8,12 +8,12 @@ from prospector.tools.vulture import VultureTool
 
 
 class TestVultureTool(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         with patch("sys.argv", [""]):
             self.config = ProspectorConfig()
         self.vulture_tool = VultureTool()
 
-    def test_vulture_find_dead_code(self):
+    def test_vulture_find_dead_code(self) -> None:
         found_files = FileFinder(Path(__file__).parent / "testpath/testfile.py")
         self.vulture_tool.configure(self.config, found_files)
         messages = self.vulture_tool.run(found_files)


### PR DESCRIPTION
## Description

Remove the `--zero-exit` Prospector argument.

Complete the “exclude” to make the check pass.
