### PR TITLE
Don't pass the filenames in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,16 +58,8 @@ repos:
         language: python
         types: [python]
         require_serial: true
+        pass_filenames: false
         verbose: true
         additional_dependencies:
           # the following are needed to run mypy.
           - types-PyYAML
-        exclude: |-
-          (?x)^(
-            tests/.*/testdata/.*
-            |tests/tools/.*/testpath/.*
-            |tests/tools/pylint/pylint_configs/.*
-            |tests/tools/pylint/test_no_init_found/.*
-            |tests/is_python/scrypt.*
-            |docs/conf\.py
-          )$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
   language: python
   types: [python]
   require_serial: true
+  pass_filenames: false


### PR DESCRIPTION
## Description

Don't pass the filenames in pre-commit hook

## Related Issue

https://github.com/prospector-dev/prospector/pull/754#issuecomment-2798818284

## Motivation and Context

Have a better coherence between the Prospector command and the pre-commit hook.
