### PR TITLE
Add GitLab formatter

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,7 +37,7 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 +----------------------+----------------------------------------------------------------------------+
 | ``vscode``           | | Support for `vscode_python_plugin`_                                      |
 +----------------------+----------------------------------------------------------------------------+
-| ``gitlab``           | | Support for `gitlab_code_climate_report_format`_                                      |
+| ``gitlab``           | | Support for `gitlab_code_climate_report_format`_                         |
 +----------------------+----------------------------------------------------------------------------+
 | ``grouped``          | | Similar to ``text``, but groups all message on the same line together    |
 |                      | | rather than having a separate entry per message.                         |

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,6 +3,7 @@ Command Line Usage
 
 .. _issue_16: https://github.com/PyCQA/prospector/issues/16
 .. _vscode_python_plugin: https://marketplace.visualstudio.com/items?itemName=donjayamanne.python
+.. _gitlab_code_climate_report_format: https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
 
 The simplest way to run prospector is from the project root with no arguments. It will try to figure everything else out itself and provide sensible defaults::
 
@@ -35,6 +36,8 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 | ``emacs``            | | Support for emacs compilation output mode, see `issue_16`_.              |
 +----------------------+----------------------------------------------------------------------------+
 | ``vscode``           | | Support for `vscode_python_plugin`_                                      |
++----------------------+----------------------------------------------------------------------------+
+| ``gitlab``           | | Support for `gitlab_code_climate_report_format`_                                      |
 +----------------------+----------------------------------------------------------------------------+
 | ``grouped``          | | Similar to ``text``, but groups all message on the same line together    |
 |                      | | rather than having a separate entry per message.                         |

--- a/prospector/formatters/__init__.py
+++ b/prospector/formatters/__init__.py
@@ -1,4 +1,4 @@
-from . import emacs, grouped, json, pylint, pylint_parseable, text, vscode, xunit, yaml
+from . import emacs, gitlab, grouped, json, pylint, pylint_parseable, text, vscode, xunit, yaml
 from .base import Formatter
 
 __all__ = ("FORMATTERS", "Formatter")
@@ -7,6 +7,7 @@ __all__ = ("FORMATTERS", "Formatter")
 FORMATTERS: dict[str, type[Formatter]] = {
     "json": json.JsonFormatter,
     "text": text.TextFormatter,
+    "gitlab": gitlab.GitlabFormatter,
     "grouped": grouped.GroupedFormatter,
     "emacs": emacs.EmacsFormatter,
     "yaml": yaml.YamlFormatter,

--- a/prospector/formatters/gitlab.py
+++ b/prospector/formatters/gitlab.py
@@ -1,0 +1,47 @@
+import hashlib
+import json
+from typing import Any
+
+from prospector.formatters.base import Formatter
+
+__all__ = ("GitlabFormatter",)
+
+
+class GitlabFormatter(Formatter):
+    """
+    This formatter outputs messages in the GitLab Code Quality report format.
+    https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
+    """
+
+    def render(self, summary: bool = True, messages: bool = True, profile: bool = False) -> str:
+        output: list[dict[str, Any]] = []
+        fingerprints = set()
+
+        if messages:
+            for message in sorted(self.messages):
+                # Make sure that we do not get a fingerprint that is already in use
+                # by adding in the previously generated one.
+                message_hash = ":".join([str(message.location.path), str(message.location.line), message.code])
+                sha256_hash = hashlib.sha256(message_hash.encode())
+                while sha256_hash.hexdigest() in fingerprints:
+                    # In cases of hash collisions, new hashes will be generated.
+                    sha256_hash.update(sha256_hash.hexdigest().encode())
+
+                fingerprint = sha256_hash.hexdigest()
+                fingerprints.add(fingerprint)
+
+                output.append(
+                    {
+                        "type": "issue",
+                        "check_name": message.code,
+                        "description": f"{message.source}[{message.code}]: {message.message.strip()}",
+                        "severity": "major",
+                        "location": {
+                            "path": str(self._make_path(message.location)),
+                            "lines": {"begin": message.location.line, "end": message.location.line_end},
+                        },
+                        "fingerprint": fingerprint,
+                    }
+                )
+
+        return json.dumps(output, indent=2)

--- a/prospector/formatters/gitlab.py
+++ b/prospector/formatters/gitlab.py
@@ -23,9 +23,14 @@ class GitlabFormatter(Formatter):
                 # by adding in the previously generated one.
                 message_hash = ":".join([str(message.location.path), str(message.location.line), message.code])
                 sha256_hash = hashlib.sha256(message_hash.encode())
+                MAX_ITERATIONS = 1000
+                iteration_count = 0
                 while sha256_hash.hexdigest() in fingerprints:
                     # In cases of hash collisions, new hashes will be generated.
                     sha256_hash.update(sha256_hash.hexdigest().encode())
+                    iteration_count += 1
+                    if iteration_count > MAX_ITERATIONS:
+                        raise RuntimeError("Maximum iteration limit reached while resolving hash collisions.")
 
                 fingerprint = sha256_hash.hexdigest()
                 fingerprints.add(fingerprint)


### PR DESCRIPTION
## Description

Add GitLab formatter

## Related Issue

https://github.com/prospector-dev/prospector/issues/765

## Motivation and Context

When running prospector on GitLab CI/CD, it is not possible to use its report as is, because GitLab uses the "CodeClimate report format", which is not supported.

## How Has This Been Tested?

I tested these changes and got the expected result.
![image](https://github.com/user-attachments/assets/16ecba8b-8790-4571-b152-fab163bb8dda)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
