### PR TITLE
Add blending for use lazy % formatting in logging functions

### DIFF
--- a/prospector/blender_combinations.yaml
+++ b/prospector/blender_combinations.yaml
@@ -1347,3 +1347,7 @@ combinations:
     - ruff: D419
     - pycodestyle: D419
     - pep257: D419
+
+  - # Use lazy % formatting in logging functions
+    - pylint: logging-fstring-interpolation
+    - ruff: G004


### PR DESCRIPTION
## Description

Add blending about Use lazy % formatting in logging functions (PyLint) and 
Logging statement uses f-string (Ruff).

## Motivation and Context

Better PyLint and Ruff integration

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

