### PR TITLE
Make the output capture stream a properly initialised text stream

### DIFF
--- a/prospector/tools/utils.py
+++ b/prospector/tools/utils.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
 import sys
-from io import TextIOWrapper
+from io import BytesIO, TextIOWrapper
 from types import TracebackType
 
 from typing_extensions import Self
 
 
 class CaptureStream(TextIOWrapper):
-    def __init__(self, tty: bool) -> None:
+    def __init__(self, tty: bool, encoding: str | None = None, errors: str | None = None) -> None:
+        # TextIOWrapper is implemented in C: unless its __init__ runs, every inherited
+        # method and property raises "ValueError: I/O operation on uninitialized object".
+        # Since this object stands in for sys.stdout while the tools run, it has to be a
+        # usable text stream - wrap a throwaway in-memory buffer to get one.
+        super().__init__(
+            BytesIO(),
+            encoding=encoding or "utf-8",
+            errors=errors or "replace",
+            write_through=True,
+        )
         self.contents = ""
         self._tty = tty
 
@@ -24,6 +34,13 @@ class CaptureStream(TextIOWrapper):
 
     def isatty(self) -> bool:
         return self._tty
+
+    def readable(self) -> bool:
+        # this stream stands in for stdout/stderr, the in-memory buffer is write-only
+        return False
+
+    def seekable(self) -> bool:
+        return False
 
 
 class CaptureOutput:
@@ -44,8 +61,10 @@ class CaptureOutput:
                 sys.__stdout__,
                 sys.__stderr__,
             )
-            self.stdout = CaptureStream(is_a_tty)
-            self.stderr = CaptureStream(is_a_tty)
+            encoding = getattr(sys.stdout, "encoding", None)
+            errors = getattr(sys.stdout, "errors", None)
+            self.stdout = CaptureStream(is_a_tty, encoding, errors)
+            self.stderr = CaptureStream(is_a_tty, encoding, errors)
             sys.stdout, sys.__stdout__ = self.stdout, self.stdout  # type: ignore[misc]
             sys.stderr, sys.__stderr__ = self.stderr, self.stderr  # type: ignore[misc]
         return self

--- a/tests/tools/test_capture_output.py
+++ b/tests/tools/test_capture_output.py
@@ -1,0 +1,46 @@
+import io
+import sys
+
+from prospector.tools.utils import CaptureOutput
+
+
+def test_captured_stdout_is_an_initialised_text_stream() -> None:
+    """
+    While output is captured, ``sys.stdout`` must still behave like a text stream.
+
+    Prospector replaces ``sys.stdout``/``sys.__stdout__`` for the whole duration of a
+    tool run, so any code touching the standard stream (a pylint plugin, Django, a
+    progress bar...) talks to ``CaptureStream`` instead of the real one.
+    """
+    with CaptureOutput(hide=True) as capture:
+        stream = sys.stdout
+        encoding = stream.encoding
+        errors = stream.errors
+        writable = stream.writable()
+        readable = stream.readable()
+        print("hello")
+
+    assert capture.get_hidden_stdout() == "hello\n"
+    assert isinstance(encoding, str)
+    assert encoding != ""
+    assert isinstance(errors, str)
+    assert errors != ""
+    assert writable is True
+    assert readable is False
+
+
+def test_captured_stdout_fileno_raises_unsupported_operation() -> None:
+    """
+    ``fileno()`` has no file descriptor to return, but it must fail the way other
+    in-memory streams do (like ``io.StringIO``), not with "uninitialized object"."""
+    raised: BaseException
+    with CaptureOutput(hide=True):
+        stream = sys.stdout
+        try:
+            stream.fileno()
+        except BaseException as err:  # noqa: BLE001 - the exception type is what we assert on
+            raised = err
+        else:
+            raised = AssertionError("fileno() did not raise")
+
+    assert isinstance(raised, io.UnsupportedOperation), repr(raised)


### PR DESCRIPTION
While the tools run, prospector replaces `sys.stdout`, `sys.stderr`, `sys.__stdout__` and
`sys.__stderr__` with a `CaptureStream` (`CaptureOutput.__enter__`, enabled unless
`--direct-tool-stdout` is passed). `CaptureStream` subclasses `TextIOWrapper` but its
`__init__` never calls `super().__init__()`, and `TextIOWrapper` is a C type: until it is
initialised, every inherited method and property raises.

So for the whole duration of a run, any code that touches the standard streams sees this:

```python
sys.stdout.fileno()     # ValueError: I/O operation on uninitialized object
sys.stdout.errors       # ValueError: I/O operation on uninitialized object
sys.stdout.name         # ValueError: I/O operation on uninitialized object
sys.stdout.readable()   # ValueError: I/O operation on uninitialized object
sys.stdout.encoding     # None  (the real stream returns 'utf-8')
```

That is the same failure mode as #703, where Django's logging configuration crashed a whole
run on `sys.stdout.isatty()`; it was fixed in 16af5ba by adding `isatty()` to the class. Every
other stream member is still missing, so the next library that asks for one crashes again.

This wraps a throwaway in-memory buffer so `CaptureStream` is a real, usable text stream, and
passes the encoding/errors of the stream being replaced so tools that read `sys.stdout.encoding`
see the truth. `fileno()` now raises `io.UnsupportedOperation` — the same thing `io.StringIO()`
does, and something callers already handle. `readable()`/`seekable()` are kept `False` because
this object stands in for stdout.

Capturing behaviour itself is unchanged: `write()` still appends to `contents`, `close()` and
`flush()` are still no-ops.

Added `tests/tools/test_capture_output.py`, which fails on master with
`ValueError: I/O operation on uninitialized object`.
