### PR TITLE
Honour [tool.vulture] in pyproject.toml

### DIFF
--- a/prospector/tools/vulture/__init__.py
+++ b/prospector/tools/vulture/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from vulture import Vulture
+from vulture.config import InputError, make_config
 
 from prospector.encoding import CouldNotHandleEncoding, read_py_file
 from prospector.finder import FileFinder
@@ -15,9 +16,39 @@ if TYPE_CHECKING:
     from prospector.config import ProspectorConfig
 
 
+def _pyproject_settings(workdir: Path) -> dict[str, Any]:
+    """
+    Read the `[tool.vulture]` section of the project's pyproject.toml.
+
+    Vulture reads this section itself when it is run from the command line, so
+    without it a project that configures `ignore_decorators` gets different
+    results depending on whether it ran vulture or prospector. See #505.
+
+    A missing or unreadable file means no settings, not an error: prospector
+    runs in plenty of projects that have neither.
+    """
+    pyproject = workdir / "pyproject.toml"
+    if not pyproject.is_file():
+        return {}
+
+    try:
+        with pyproject.open("rb") as handle:
+            # `argv` is only there to satisfy vulture's own argument parser,
+            # which insists on a path; the paths it produces are unused, as
+            # prospector has already found the files itself.
+            return make_config(argv=[str(workdir)], tomlfile=handle)
+    except (InputError, OSError, ValueError):
+        return {}
+
+
 class ProspectorVulture(Vulture):
-    def __init__(self, found_files: FileFinder) -> None:
-        Vulture.__init__(self, verbose=False)
+    def __init__(
+        self,
+        found_files: FileFinder,
+        ignore_names: list[str] | None = None,
+        ignore_decorators: list[str] | None = None,
+    ) -> None:
+        Vulture.__init__(self, verbose=False, ignore_names=ignore_names, ignore_decorators=ignore_decorators)
         self._files = found_files
         self._internal_messages: list[Message] = []
         self.file: Path | None = None
@@ -79,14 +110,24 @@ class VultureTool(ToolBase):
         ToolBase.__init__(self)
         self._vulture = None
         self.ignore_codes: list[str] = []
+        self.ignore_names: list[str] = []
+        self.ignore_decorators: list[str] = []
 
     def configure(  # pylint: disable=useless-return
         self, prospector_config: ProspectorConfig, found_files: FileFinder
     ) -> tuple[str | None, Iterable[Message] | None] | None:
         self.ignore_codes = prospector_config.get_disabled_messages("vulture")
+
+        settings = _pyproject_settings(prospector_config.workdir)
+        self.ignore_names = settings.get("ignore_names", [])
+        self.ignore_decorators = settings.get("ignore_decorators", [])
         return None
 
     def run(self, found_files: FileFinder) -> list[Message]:
-        vulture = ProspectorVulture(found_files)
+        vulture = ProspectorVulture(
+            found_files,
+            ignore_names=self.ignore_names,
+            ignore_decorators=self.ignore_decorators,
+        )
         vulture.scavenge()
         return [message for message in vulture.get_messages() if message.code not in self.ignore_codes]

--- a/tests/tools/vulture/pyproject_config/app.py
+++ b/tests/tools/vulture/pyproject_config/app.py
@@ -1,0 +1,27 @@
+class App:
+    def get(self, path: str):
+        return lambda func: func
+
+    def post(self, path: str):
+        return lambda func: func
+
+
+app = App()
+
+
+@app.get("/items")
+def read_items():
+    return []
+
+
+@app.post("/items")
+def create_item():
+    return {}
+
+
+def keep_me():
+    return 1
+
+
+def truly_unused():
+    return 2

--- a/tests/tools/vulture/pyproject_config/pyproject.toml
+++ b/tests/tools/vulture/pyproject_config/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.vulture]
+ignore_decorators = ["@app.get", "@app.post"]
+ignore_names = ["keep_me"]

--- a/tests/tools/vulture/test_vulture_tool.py
+++ b/tests/tools/vulture/test_vulture_tool.py
@@ -13,6 +13,31 @@ class TestVultureTool(TestCase):
             self.config = ProspectorConfig()
         self.vulture_tool = VultureTool()
 
+    def test_vulture_reads_pyproject_config(self) -> None:
+        """
+        `[tool.vulture]` in pyproject.toml is honoured.
+
+        Vulture reads that section itself, so without this the same project
+        gets different results from `vulture` and from `prospector`.
+
+        see https://github.com/prospector-dev/prospector/issues/505
+        """
+        testpath = Path(__file__).parent / "pyproject_config"
+        with patch("sys.argv", [""]):
+            config = ProspectorConfig(workdir=testpath)
+
+        found_files = FileFinder(testpath / "app.py")
+        tool = VultureTool()
+        tool.configure(config, found_files)
+        messages = [message.message for message in tool.run(found_files)]
+
+        # ignored by `ignore_decorators`, and by `ignore_names`
+        for name in ("read_items", "create_item", "keep_me"):
+            assert not any(name in message for message in messages), f"{name} should have been ignored, got {messages}"
+
+        # everything else is still reported
+        assert any("truly_unused" in message for message in messages), messages
+
     def test_vulture_find_dead_code(self) -> None:
         found_files = FileFinder(Path(__file__).parent / "testpath/testfile.py")
         self.vulture_tool.configure(self.config, found_files)


### PR DESCRIPTION
Fixes #505.

`VultureTool` never read `[tool.vulture]`, and `ProspectorVulture.__init__` called `Vulture.__init__(self, verbose=False)` — dropping the two keyword arguments vulture accepts for exactly this, `ignore_names` and `ignore_decorators`. So the same project answered differently depending on which command ran.

With the reporter's setup — `ignore_decorators = ["@app.get", "@app.post"]`, `ignore_names = ["keep_me"]`, and a file holding two decorated routes, `keep_me`, and one genuinely dead function:

```console
$ vulture app.py
app.py:2: unused variable 'path' (100% confidence)
app.py:5: unused variable 'path' (100% confidence)
app.py:26: unused function 'truly_unused' (60% confidence)

$ prospector --tool vulture            # before
  Line: 12  vulture: unused-function / Unused function 'read_items'
  Line: 17  vulture: unused-function / Unused function 'create_item'
  Line: 22  vulture: unused-function / Unused function 'keep_me'
  Line: 26  vulture: unused-function / Unused function 'truly_unused'
  ... plus the two unused variables

$ prospector --tool vulture            # after
  Line: 2   vulture: unused-variable / Unused variable 'path'
  Line: 5   vulture: unused-variable / Unused variable 'path'
  Line: 26  vulture: unused-function / Unused function 'truly_unused'
```

The two now agree.

The section is read with vulture's own `make_config`, rather than a hand-rolled TOML read, so the two can't drift on what a key means. The `argv` it's given is only there to satisfy vulture's argument parser, which insists on a path; the paths it produces are discarded, since prospector has already found the files. A missing or malformed `pyproject.toml` yields no settings rather than an error — prospector runs in plenty of projects that have neither.

**Deliberately not included:** `min_confidence` and `exclude`. Both are in the same section, but prospector does its own file finding and its own message filtering, so honouring them here means deciding how they compose with `ignore-paths` and with the profile's `disable` list — a bigger question than this issue asks. Say the word if you'd like them in and I'll add them.

`test_vulture_reads_pyproject_config` runs the tool against a fixture project carrying that config; it fails on current `master` with `read_items should have been ignored` and passes with the change. `ruff format` and `ruff check` are clean under the repo's own configuration. The wider suite has four collection errors from optional tools that aren't installed here — the same four, on the clean tree and with this branch.

The thread also mentions `pydocstyle` having the same shape of problem; that's a separate tool wrapper and I've left it alone.

AI-assisted (LLM used for drafting); the runs above are mine.
